### PR TITLE
Fixed docker volume creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,22 +30,26 @@ build:
 	docker build --target build --network nuodb-net -f dockers/centos/Dockerfile -t nuodb/node-nuodb:$(VERSION)-build .
 
 #:help: test        | Runs the `test` target, building and testing the driver.
+#changed to properly create and mount volumes
 .PHONY: test
 test: build
 	docker volume create cores
-	docker run -it --cap-add=SYS_PTRACE --memory 1g --volume $(CURDIR)/cores:/cores --volume $(CURDIR)/valgrind:/valgrind --name test --rm --network nuodb-net nuodb/node-nuodb:$(VERSION)-build npm run test
+	docker volume create valgrind
+	docker run -it --cap-add=SYS_PTRACE --memory 1g --volume cores:/cores --volume valgrind:/valgrind --name test --rm --network nuodb-net nuodb/node-nuodb:$(VERSION)-build npm run test
 
 #:help: test-only   | Runs the `test` target, testing the driver without building the Docker.
 .PHONY: test-only
 test-only:
 	docker volume create cores
-	docker run -it --cap-add=SYS_PTRACE --memory 1g --volume $(CURDIR)/cores:/cores --volume $(CURDIR)/valgrind:/valgrind --name test --rm --network nuodb-net nuodb/node-nuodb:$(VERSION)-build npm run test
+	docker volume create valgrind
+	docker run -it --cap-add=SYS_PTRACE --memory 1g --volume cores:/cores --volume valgrind:/valgrind --name test --rm --network nuodb-net nuodb/node-nuodb:$(VERSION)-build npm run test
 
 #:help: valgrind    | Runs the `valgrind` target, building the driver and running a sample application under valgrind.
 .PHONY: valgrind
 valgrind: build
 	docker volume create cores
-	docker run -it --cap-add=SYS_PTRACE --memory 1g --volume $(CURDIR)/cores:/cores --volume $(CURDIR)/valgrind:/valgrind --name test --rm --network nuodb-net nuodb/node-nuodb:$(VERSION)-build npm run valgrind
+	docker volume create valgrind
+	docker run -it --cap-add=SYS_PTRACE --memory 1g --volume cores:/cores --volume valgrind:/valgrind --name test --rm --network nuodb-net nuodb/node-nuodb:$(VERSION)-build npm run valgrind
 
 #:help: run-build   | Runs the `build` Docker variant
 .PHONY: run-build

--- a/build-support/scripts/brute
+++ b/build-support/scripts/brute
@@ -2,4 +2,4 @@
 
 export VERSION=3.0.0
 docker volume create cores
-while docker run -it --cap-add=SYS_PTRACE --volume $(pwd)/cores:/cores --name test --rm --network nuodb-net nuodb/node-nuodb:${VERSION}-build npm run test; do :; done
+while docker run -it --cap-add=SYS_PTRACE --volume cores:/cores --name test --rm --network nuodb-net nuodb/node-nuodb:${VERSION}-build npm run test; do :; done

--- a/build-support/scripts/dn
+++ b/build-support/scripts/dn
@@ -2,4 +2,7 @@
 
 docker stop te1 sm1 ad1
 docker network rm nuodb-net
-rm -fr vol1 vol2
+##rm -fr vol1 vol2
+
+#added to properly remove newly created volumes
+docker volume rm vol1 vol2 cores valgrind

--- a/build-support/scripts/up
+++ b/build-support/scripts/up
@@ -12,15 +12,15 @@ docker run -d --name ad1 --rm \
     -p 48005:48005 \
     -e "NUODB_DOMAIN_ENTRYPOINT=ad1" \
     ${IMG_NAME} nuoadmin
+#changed to properly create and mount volumes
+docker volume create vol1
 
-mkdir vol1
-chmod a+rw vol1
-mkdir vol2
-chmod a+rw vol2
+docker volume create vol2
+
 
 docker run -d --name sm1 --hostname sm1 --rm \
-    --volume $(pwd)/vol1:/var/opt/nuodb/backup \
-    --volume $(pwd)/vol2:/var/opt/nuodb/archive \
+    --volume vol1:/var/opt/nuodb/backup \
+    --volume vol2:/var/opt/nuodb/archive \
     --net nuodb-net ${IMG_NAME} nuodocker \
     --api-server ad1:8888 start sm \
     --db-name test --server-id ad1 \


### PR DESCRIPTION
Volumes were being created by using "mkdir" and then mounting the docker volume on those volumes. This has been changed to use docker volume create.