### PR TITLE
Fix bugs in driver C++ code, update to work with node@17.

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -34,21 +34,22 @@
         "-g",
         "-Wall",
         "-Werror",
-        "-Wextra"
+        "-Wextra",
+        "-Wno-cast-function-type"
       ],
       "cflags_cc": [
         "-g",
         "-Wall",
         "-Werror",
         "-Wextra",
-        "-std=c++11"
+        "-std=c++14"
       ],
       "variables": {
         "nuodb_home": "<!(echo ${NUODB_HOME-\"/opt/nuodb\"})"
       },
       "include_dirs": [
         "src",
-        "/opt/nuodb/include/",
+        "<(nuodb_home)/include/",
         "<!(node -e \"require('nan')\")"
       ],
       "libraries": [

--- a/examples/query.js
+++ b/examples/query.js
@@ -1,0 +1,36 @@
+// Copyright (c) 2022, NuoDB, Inc.
+// All rights reserved.
+//
+// Redistribution and use permitted under the terms of the 3-clause BSD license.
+
+'use strict';
+
+const { Driver } = require('..');
+const config = require('../test/config');
+
+var driver = new Driver();
+
+driver.connect(config)
+  .then((conn) => {
+    conn.execute('select tablename from system.tables')
+      .then((results) => {
+        results.getRows()
+          .then((rows) => {
+            console.log(rows);
+          });
+      });
+  });
+
+// async variation
+/*
+async function query(conn, sql) {
+  let results = await conn.execute(sql);
+  return await results.getRows();
+}
+
+(async () => {
+  let conn = await driver.connect(config);
+  let rows = await query(conn, 'select tablename from system.tables');
+  console.log(rows);
+})()
+*/

--- a/package.json
+++ b/package.json
@@ -23,15 +23,15 @@
   "private": true,
   "gypfile": true,
   "dependencies": {
-    "bindings": "^1.3.1",
-    "nan": "^2.11.1",
-    "node-gyp": "^3.8.0",
-    "segfault-handler": "^1.0.1"
+    "bindings": "^1.5.0",
+    "nan": "^2.15.0",
+    "node-gyp": "^8.4.1",
+    "segfault-handler": "^1.3.0"
   },
   "devDependencies": {
-    "async": "^2.6.1",
-    "eslint": "^5.9.0",
-    "mocha": "^5.2.0",
+    "async": "^3.2.3",
+    "eslint": "^8.6.0",
+    "mocha": "^9.1.3",
     "okay": "^1.0.0",
     "should": "^13.2.3"
   },

--- a/src/NuoJsConnection.cpp
+++ b/src/NuoJsConnection.cpp
@@ -82,23 +82,23 @@ Local<Object> Connection::createFrom(class NuoDB::Connection* conn)
     return scope.Escape(obj);
 }
 
-class CloseWorker : public Nan::AsyncWorker
+class ConnectionCloseWorker : public Nan::AsyncWorker
 {
 public:
-    CloseWorker(Nan::Callback* callback, Connection* self)
+    ConnectionCloseWorker(Nan::Callback* callback, Connection* self)
         : Nan::AsyncWorker(callback), self(self)
     {
-        TRACE("CloseWorker::CloseWorker");
+        TRACE("ConnectionCloseWorker::ConnectionCloseWorker");
     }
 
-    virtual ~CloseWorker()
+    virtual ~ConnectionCloseWorker()
     {
-        TRACE("CloseWorker::~CloseWorker");
+        TRACE("ConnectionCloseWorker::~ConnectionCloseWorker");
     }
 
     virtual void Execute()
     {
-        TRACE("CloseWorker::Execute");
+        TRACE("ConnectionCloseWorker::Execute");
         try {
             self->doClose();
         } catch (std::exception& e) {
@@ -135,7 +135,7 @@ NAN_METHOD(Connection::close)
     }
     Nan::Callback* callback = new Nan::Callback(info[0].As<Function>());
 
-    CloseWorker* worker = new CloseWorker(callback, self);
+    ConnectionCloseWorker* worker = new ConnectionCloseWorker(callback, self);
     worker->SaveToPersistent("nuodb:Connection", info.This());
     Nan::AsyncQueueWorker(worker);
 }
@@ -416,6 +416,8 @@ NAN_METHOD(Connection::execute)
 NuoDB::PreparedStatement* Connection::createStatement(std::string sql, Local<Array> binds)
 {
     Nan::HandleScope scope;
+    Isolate* isolate = Isolate::GetCurrent();
+    Local<Context> ctx = isolate->GetCurrentContext();
 
     if (!isConnected()) {
         std::string message = ErrMsg::get(ErrMsgType::errConnectionClosed);
@@ -426,7 +428,7 @@ NuoDB::PreparedStatement* Connection::createStatement(std::string sql, Local<Arr
     try {
         statement = connection->prepareStatement(sql.c_str());
         for (size_t index = 0; index < binds->Length(); index++) {
-            Local<Value> value = binds->Get(index);
+            Local<Value> value = binds->Get(ctx, index).ToLocalChecked();
 
             int sqlIdx = index + 1;
             int sqlType = Type::fromEsType(typeOf(value));
@@ -522,6 +524,7 @@ NAN_SETTER(Connection::setReadOnly)
 {
     TRACE("Connection::SetReadOnly");
     Nan::HandleScope scope;
+    Isolate* isolate = Isolate::GetCurrent();
 
     Connection* self = Nan::ObjectWrap::Unwrap<Connection>(info.This());
 
@@ -538,7 +541,7 @@ NAN_SETTER(Connection::setReadOnly)
     }
 
     if (!value.IsEmpty() && value->IsBoolean()) {
-        self->setReadOnly(value->BooleanValue());
+        self->setReadOnly(value->BooleanValue(isolate));
     }
 }
 
@@ -564,6 +567,7 @@ NAN_SETTER(Connection::setAutoCommit)
 {
     TRACE("Connection::SetAutoCommit");
     Nan::HandleScope scope;
+    Isolate* isolate = Isolate::GetCurrent();
 
     Connection* self = Nan::ObjectWrap::Unwrap<Connection>(info.This());
 
@@ -580,7 +584,7 @@ NAN_SETTER(Connection::setAutoCommit)
     }
 
     if (!value.IsEmpty() && value->IsBoolean()) {
-        self->setAutoCommit(value->BooleanValue());
+        self->setAutoCommit(value->BooleanValue(isolate));
     }
 }
 

--- a/src/NuoJsConnection.h
+++ b/src/NuoJsConnection.h
@@ -40,7 +40,7 @@ private:
     void doRollback();
 
     static NAN_METHOD(close);
-    friend class CloseWorker;
+    friend class ConnectionCloseWorker;
     void doClose();
 
     static NAN_GETTER(getReadOnly);

--- a/src/NuoJsDriver.cpp
+++ b/src/NuoJsDriver.cpp
@@ -112,6 +112,8 @@ NAN_METHOD(Driver::connect)
 {
     TRACE("Driver::connect");
     Nan::HandleScope scope;
+    Isolate* isolate = Isolate::GetCurrent();
+    Local<Context> ctx = isolate->GetCurrentContext();
 
     if (!info.Length() || !info[(info.Length() - 1)]->IsFunction()) {
         Nan::ThrowError("connect arg count zero, or last arg is not a function");
@@ -135,7 +137,7 @@ NAN_METHOD(Driver::connect)
 
     Params params;
     try {
-        storeJsonParams(info[0]->ToObject(), params);
+        storeJsonParams(info[0]->ToObject(ctx).ToLocalChecked(), params);
     } catch (std::exception& e) {
         std::string message = ErrMsg::get(ErrMsgType::errBadConfiguration, e.what());
         Nan::ThrowError(message.c_str());

--- a/src/NuoJsJson.cpp
+++ b/src/NuoJsJson.cpp
@@ -12,6 +12,9 @@ namespace NuoJs
 std::string getJsonString(Local<Object> object, std::string key, std::string defaultValue)
 {
     Nan::EscapableHandleScope scope;
+    Isolate* isolate = Isolate::GetCurrent();
+    Local<Context> ctx = isolate->GetCurrentContext();
+
     std::string value = defaultValue;
     MaybeLocal<Value> maybe = Nan::Get(object, Nan::New(key).ToLocalChecked());
     Local<Value> local;
@@ -20,7 +23,7 @@ std::string getJsonString(Local<Object> object, std::string key, std::string def
             std::string message = ErrMsg::get(ErrMsgType::errInvalidPropertyType, key.c_str());
             throw std::runtime_error(message);
         }
-        Nan::Utf8String utf8str(local->ToString());
+        Nan::Utf8String utf8str(local->ToString(ctx).ToLocalChecked());
         value = std::string(*utf8str, static_cast<size_t>(utf8str.length()));
     }
     return value;
@@ -61,6 +64,8 @@ uint32_t getJsonUint(Local<Object> object, std::string key, uint32_t defaultValu
 bool getJsonBoolean(Local<Object> object, std::string key, bool defaultValue)
 {
     Nan::EscapableHandleScope scope;
+    Isolate* isolate = Isolate::GetCurrent();
+
     bool value = defaultValue;
     MaybeLocal<Value> maybe = Nan::Get(object, Nan::New(key).ToLocalChecked());
     Local<Value> local;
@@ -69,7 +74,7 @@ bool getJsonBoolean(Local<Object> object, std::string key, bool defaultValue)
             std::string message = ErrMsg::get(ErrMsgType::errInvalidPropertyType, key.c_str());
             throw std::runtime_error(message);
         }
-        value = local->ToBoolean()->Value();
+        value = local->ToBoolean(isolate)->Value();
     }
     return value;
 }

--- a/src/NuoJsParams.cpp
+++ b/src/NuoJsParams.cpp
@@ -15,6 +15,9 @@ namespace NuoJs
 void storeJsonParam(Local<Object> object, Params& params, std::string key, bool required)
 {
     Nan::HandleScope scope;
+    Isolate* isolate = Isolate::GetCurrent();
+    Local<Context> ctx = isolate->GetCurrentContext();
+
     MaybeLocal<Value> maybe = Nan::Get(object, Nan::New(key).ToLocalChecked());
     Local<Value> local;
     if (maybe.ToLocal(&local)) {
@@ -22,7 +25,7 @@ void storeJsonParam(Local<Object> object, Params& params, std::string key, bool 
             std::string message = ErrMsg::get(ErrMsgType::errInvalidPropertyType, key.c_str());
             throw std::runtime_error(message);
         }
-        Nan::Utf8String utf8str(local->ToString());
+        Nan::Utf8String utf8str(local->ToString(ctx).ToLocalChecked());
         params[key] = std::string(*utf8str, static_cast<size_t>(utf8str.length()));
     } else if (required) {
         std::string message = ErrMsg::get(ErrMsgType::errMissingProperty, key.c_str());
@@ -33,6 +36,9 @@ void storeJsonParam(Local<Object> object, Params& params, std::string key, bool 
 void storeJsonParamDefault(Local<Object> object, Params& params, std::string key, std::string value)
 {
     Nan::HandleScope scope;
+    Isolate* isolate = Isolate::GetCurrent();
+    Local<Context> ctx = isolate->GetCurrentContext();
+
     MaybeLocal<Value> maybe = Nan::Get(object, Nan::New(key).ToLocalChecked());
     Local<Value> local;
     if (maybe.ToLocal(&local)) {
@@ -40,7 +46,7 @@ void storeJsonParamDefault(Local<Object> object, Params& params, std::string key
             std::string message = ErrMsg::get(ErrMsgType::errInvalidPropertyType, key.c_str());
             throw std::runtime_error(message);
         }
-        Nan::Utf8String utf8str(local->ToString());
+        Nan::Utf8String utf8str(local->ToString(ctx).ToLocalChecked());
         value = std::string(*utf8str, static_cast<size_t>(utf8str.length()));
     }
     params[key] = value;

--- a/src/NuoJsResultSet.h
+++ b/src/NuoJsResultSet.h
@@ -31,7 +31,7 @@ private:
 
     // Release a database result set asynchronously.
     static NAN_METHOD(close);
-    friend class CloseWorker;
+    friend class ResultSetCloseWorker;
     void doClose();
 
     static NAN_METHOD(getRows);

--- a/test/config.js
+++ b/test/config.js
@@ -6,7 +6,7 @@
 var config = {};
 
 config.database = 'test';
-config.hostname = 'ad1';
+config.hostname = 'localhost';
 config.port = 48004;
 config.user = 'dba';
 config.password = 'dba';


### PR DESCRIPTION
= Driver bugs

CloseWorker defined twice in the same namespace, once in
NuoJsConnection.cpp and once in NuoJsResultSet.cpp. This violates
ODR and resulted in incorrect behavior. Class names changed to
ConnectionCloseWorker and ResultSetCloseWorker, respectively.

Add isolate and context where needed to comply with node@17.

Used MaybeLocal where needed.

Fixed null handling to avoid trying to construct a std::string from
nullptr.

Added examples directory with one simple query example that can be run
outside of mocha.

= Update to work with node@17 and latest dependencies

Adjust binding.gyp to compile c++14 and to ignore cast-function-type
warnings to make node-gyp compile with more recent gcc versions.

= Other

Changed a hardcoded /opt/nuodb to use NUODB_HOME.

Change config to assume test database is running on localhost.