### PR TITLE
Ecoombes/query tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "build": "node-gyp rebuild -d",
     "lint": "eslint index.js lib/*.js test/*.js",
     "this-test": "node-gyp rebuild -d && npm run lint && mocha --reporter spec --bail --check-leaks -g '22. typeInteger.js'",
-    "test": "node-gyp rebuild -d && npm run lint && mocha --reporter spec --bail --check-leaks test/",
+    "test": "node-gyp rebuild -d && npm run lint && mocha --reporter spec --bail --timeout 10000 --check-leaks test/",
     "valgrind": "node-gyp rebuild -d && G_SLICE=always-malloc G_DEBUG=gc-friendly valgrind -v --tool=memcheck --leak-check=full --show-reachable=yes --num-callers=40 --log-file=/valgrind/valgrind.log $(which node) valgrind.js",
     "valgrind-test": "node-gyp rebuild -d && G_SLICE=always-malloc G_DEBUG=gc-friendly valgrind -v --tool=memcheck --leak-check=full --show-reachable=yes --num-callers=40 --log-file=/valgrind/valgrind.log mocha --reporter spec --bail --check-leaks test/"
   }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "NuoDB, Inc.",
   "description": "The official NuoDB driver for Node.js. Provides a high-level SQL API on top of the NuoDB Node.js Addon.",
   "license": "Apache-2.0",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "main": "index.js",
   "keywords": [
     "nuodb",

--- a/src/NuoJsConnection.cpp
+++ b/src/NuoJsConnection.cpp
@@ -336,6 +336,8 @@ public:
         if (hasResults) {
             TRACE(">>>>>> HAS RESULTS");
             results = ResultSet::createFrom(statement, options);
+        } else {
+            statement->close();
         }
         Local<Value> argv[] = {
             Nan::Null(),

--- a/src/NuoJsConnection.cpp
+++ b/src/NuoJsConnection.cpp
@@ -402,6 +402,7 @@ NAN_METHOD(Connection::execute)
     NuoDB::PreparedStatement* statement = nullptr;
     try {
         statement = self->createStatement(sql, binds);
+        statement->setQueryTimeout(options.getQueryTimeout());
     } catch (std::exception& e) {
         error = e.what();
     }

--- a/src/NuoJsDriver.cpp
+++ b/src/NuoJsDriver.cpp
@@ -167,6 +167,7 @@ NuoDB::Connection* Driver::doConnect(Params& params)
         props->putValue("user", params["user"].c_str());
         props->putValue("password", params["password"].c_str());
         props->putValue("schema", params["schema"].c_str());
+        props->putValue("direct", params["direct"].c_str());
         std::string connection_string = getConnectionString(params);
         connection->openDatabase(connection_string.c_str(), props.get());
         return connection;

--- a/src/NuoJsOptions.cpp
+++ b/src/NuoJsOptions.cpp
@@ -75,6 +75,15 @@ void Options::setReadOnly(bool v)
     readOnly = v;
 }
 
+uint32_t Options::getQueryTimeout() const
+{
+    return queryTimeout;
+}
+void Options::setQueryTimeout(uint32_t v)
+{
+    queryTimeout = v;
+}
+
 RowMode toRowMode(uint32_t value)
 {
     return (value == ROWS_AS_OBJECT) ? ROWS_AS_OBJECT : ROWS_AS_ARRAY;
@@ -87,5 +96,6 @@ void getJsonOptions(Local<Object> object, Options& options)
     options.setIsolationLevel(getJsonUint(object, "isolationLevel", options.getIsolationLevel()));
     options.setAutoCommit(getJsonBoolean(object, "autoCommit", options.getAutoCommit()));
     options.setReadOnly(getJsonBoolean(object, "readOnly", options.getReadOnly()));
+    options.setQueryTimeout(getJsonUint(object, "queryTimeout", options.getQueryTimeout()));
 }
 }

--- a/src/NuoJsOptions.h
+++ b/src/NuoJsOptions.h
@@ -34,12 +34,16 @@ public:
 
     bool getReadOnly() const;
     void setReadOnly(bool);
+
+    uint32_t getQueryTimeout() const;
+    void setQueryTimeout(uint32_t);
 private:
     RowMode rowMode;
     uint32_t fetchSize;
     uint32_t isolationLevel;
     bool autoCommit;
     bool readOnly;
+    uint32_t queryTimeout;
 };
 
 // getJsonOptions returns the JSON query options provided by the user

--- a/src/NuoJsParams.cpp
+++ b/src/NuoJsParams.cpp
@@ -20,7 +20,7 @@ void storeJsonParam(Local<Object> object, Params& params, std::string key, bool 
 
     MaybeLocal<Value> maybe = Nan::Get(object, Nan::New(key).ToLocalChecked());
     Local<Value> local;
-    if (maybe.ToLocal(&local)) {
+    if (maybe.ToLocal(&local) && !local->IsNullOrUndefined()) {
         if (!local->IsString()) {
             std::string message = ErrMsg::get(ErrMsgType::errInvalidPropertyType, key.c_str());
             throw std::runtime_error(message);
@@ -67,6 +67,8 @@ void storeJsonParams(Local<Object> object, Params& params)
     storeJsonParamDefault(object, params, "schema", "USER");
     // get the port (optional, default to 48004)
     params["port"] = std::to_string(getJsonInt(object, "port", 48004));
+
+    storeJsonParam(object, params, "direct", false);
 }
 
 std::string getConnectionString(Params& params)

--- a/src/NuoJsResultSet.cpp
+++ b/src/NuoJsResultSet.cpp
@@ -428,8 +428,12 @@ void ResultSet::doGetRows(size_t count)
                 }
 
                 default:
-                    sqlValue.setString(result->getString(column));
-                    sqlValue.setSqlType(NuoDB::NUOSQL_VARCHAR);
+                    const char* s = result->getString(column);
+                    if (!result->wasNull()) {
+                        sqlValue.setString(s);
+                        sqlValue.setSqlType(NuoDB::NUOSQL_VARCHAR);
+                    }
+                    break;
             }
             // if the last value was null, set the value to null...
             if (result->wasNull()) {

--- a/test/1.callback.js
+++ b/test/1.callback.js
@@ -1,0 +1,53 @@
+// Copyright (c) 2018-2019, NuoDB, Inc.
+// All rights reserved.
+//
+// Redistribution and use permitted under the terms of the 3-clause BSD license.
+
+'use strict';
+
+var { Driver } = require('..');
+
+var should = require('should');
+var config = require('./config.js');
+
+describe('1. testing callback', () => {
+
+  var driver = null;
+
+  before('create driver', function () {
+    driver = new Driver();
+  });
+
+  it('1.1 open and close connections using callbacks', function (done) {
+    driver.connect(config, (err, conn) => {
+      should.not.exist(err);
+      const connection = conn;
+      connection.should.be.ok();
+      connection.close((err) => {
+        should.not.exist(err);
+        done();
+      })
+      connection.should.be.ok();
+    })
+  });
+
+  it('1.2 can run the sample', function (done) {
+    driver.connect(config, (err, conn) => {
+      should.not.exist(err);
+      const connection = conn;
+      connection.should.be.ok();
+      connection.execute('SELECT 1 AS VALUE FROM DUAL', (err, results) => {
+        should.not.exist(err);
+        results.should.be.ok();
+        results.getRows((err,rows) => {
+          should.not.exist(err);
+          rows.should.be.ok();
+          connection.close((err) => {
+            should.not.exist(err);
+            done();
+          })
+        });
+      });
+    })
+  });
+});

--- a/test/10.patternMatching.js
+++ b/test/10.patternMatching.js
@@ -1,0 +1,111 @@
+// Copyright (c) 2018-2019, NuoDB, Inc.
+// All rights reserved.
+//
+// Redistribution and use permitted under the terms of the 3-clause BSD license.
+
+'use strict';
+
+var { Driver } = require('..');
+
+var should = require('should');
+var config = require('./config');
+var helper = require('./typeHelper');
+var async = require('async');
+
+const data = [
+  'hello world',
+  'hello test',
+  'test world'
+]
+
+const tableName = 'CLAUSE_TEST';
+
+const likeQuery = `select * from ${tableName} where f1 like 'hello%'`;
+const startingQuery = `select * from ${tableName} where f1 not starting with 'test'`;
+const containingQuery = `select * from ${tableName} where f1 containing 'world'`;
+const regexpQuery = `select * from ${tableName} where f1 regexp '^hello'`;
+
+
+
+describe('10. pattern matching clauses', () => {
+
+  var driver = null;
+  var connection = null;
+
+  before('open connection, init tables', async () => {
+    driver = new Driver();
+    connection = await driver.connect(config);
+    connection.should.be.ok();
+
+    await connection.execute(helper.sqlDropTable(tableName));
+    await connection.execute(helper.sqlCreateTable(tableName,'STRING'));
+    await async.series(data.map( d => 
+      async () => await connection.execute(helper.sqlInsert(tableName),[d]))
+    );
+  });
+
+  after('close connection', async () => {
+    await connection.execute(helper.sqlDropTable(tableName));
+    await connection.close();
+  });
+
+  it('10.1 LIKE clause', async () => {
+    let err = null;
+
+    try {
+      const results = await connection.execute(likeQuery);
+      results.should.be.ok();
+      const rows = await results.getRows();
+      (rows.length).should.be.eql(2);
+    } catch (e) {
+      err = e
+    }
+
+    should.not.exist(err)
+  });
+
+  it('10.2 STARTING clause', async () => {
+    let err = null;
+
+    try {
+      const results = await connection.execute(startingQuery);
+      results.should.be.ok();
+      const rows = await results.getRows();
+      (rows.length).should.be.eql(2);
+    } catch (e) {
+      err = e
+    }
+
+    should.not.exist(err)
+  });
+
+  it('10.3 CONTAINING clause', async () => {
+    let err = null;
+
+    try {
+      const results = await connection.execute(containingQuery);
+      results.should.be.ok();
+      const rows = await results.getRows();
+      (rows.length).should.be.eql(2);
+    } catch (e) {
+      err = e
+    }
+
+    should.not.exist(err)
+  });
+
+  it('10.4 REGEXP clause', async () => {
+    let err = null;
+
+    try {
+      const results = await connection.execute(regexpQuery);
+      results.should.be.ok();
+      const rows = await results.getRows();
+      (rows.length).should.be.eql(2);
+    } catch (e) {
+      err = e
+    }
+
+    should.not.exist(err)
+  });
+});

--- a/test/10.patternMatching.js
+++ b/test/10.patternMatching.js
@@ -39,7 +39,7 @@ describe('10. pattern matching clauses', () => {
 
     await connection.execute(helper.sqlDropTable(tableName));
     await connection.execute(helper.sqlCreateTable(tableName,'STRING'));
-    await async.series(data.map( d => 
+    await async.series(data.map( d =>
       async () => await connection.execute(helper.sqlInsert(tableName),[d]))
     );
   });

--- a/test/12.multipleTEs.js
+++ b/test/12.multipleTEs.js
@@ -1,0 +1,114 @@
+// Copyright (c) 2018-2019, NuoDB, Inc.
+// All rights reserved.
+//
+// Redistribution and use permitted under the terms of the 3-clause BSD license.
+
+'use strict';
+
+var { Driver } = require('..');
+
+var should = require('should');
+var config = require('./config');
+var async = require('async');
+
+const getNodeIdQuery = 'SELECT GETNODEID() FROM SYSTEM.DUAL';
+const getNodesQuery = 'SELECT * FROM SYSTEM.NODES';
+
+const errTextSystemNotSetup = `The system should have more than 2 nodes (1 SM, 1 TE) to run this test.
+  Please ensure that the test environment is properly configured to run this test and try again.`;
+
+const numConnectionsToTest = 20;
+const roundRobinDelta = numConnectionsToTest / 5;
+
+let nodes = null;
+
+const filterTEOnly = (n) => n.TYPE === "Transaction"
+describe('12. Test Connection to multiple TEs', () => {
+
+  var driver = null;
+  var connection = null;
+
+  before('open connection, init tables', async () => {
+    driver = new Driver();
+    connection = await driver.connect(config);
+    connection.should.be.ok();
+
+    let err = null;
+
+    try {
+      const results = await connection.execute(getNodesQuery);
+      results.should.be.ok();
+      nodes = await results.getRows();
+      (nodes.length).should.be.aboveOrEqual(2, errTextSystemNotSetup);
+    } catch (e) {
+      err = e
+    }
+
+    should.not.exist(err)
+
+  });
+
+  after('close connection', async () => {
+    await connection.close();
+  });
+
+  it('12.1 Test round robin', async () => {
+    let nodeResults = {};
+    const connections = [];
+
+    // open up a bunch of connections, and figure ot what node is being connected to
+    for(let i = 0; i < numConnectionsToTest; i++){
+      const nodeConnection = await driver.connect(config);
+      const results = await nodeConnection.execute(getNodeIdQuery);
+      const rows = await results.getRows();
+      (rows.length).should.be.eql(1);
+      const nodeId = rows[0]["[GETNODEID]"];
+      await results.close();
+      nodeResults[nodeId] = (nodeResults[nodeId] ?? 0) + 1;
+      connections.push(nodeConnection);
+    }
+    // close out those connections
+    await async.series(connections.map((c) => async () => {await c.close()}));
+    const numTENodes = nodes.filter(filterTEOnly).length;
+
+    // we should have at least one connection to each TE
+    (Object.keys(nodeResults).length).should.be.eql(numTENodes);
+
+    // Approximately uniform distribution of connections
+    const approxEqual = numConnectionsToTest / numTENodes;
+    Object.keys(nodeResults).forEach((k) => {
+      (nodeResults[k]).should.be.approximately(approxEqual, roundRobinDelta);
+    })
+
+  });
+
+  it('12.2 Test direct connection to multiple TEs', async () => {
+    await async.series(
+      nodes
+        .filter(filterTEOnly)
+        .map((n) => async () => {
+          // connect to each unique TE directly
+          let err = null;
+          try {
+            const nodeConfig = {... config
+              , port: n.PORT
+              , direct: "true"};
+            const nodeConnection = await driver.connect(nodeConfig);
+            nodeConnection.should.be.ok();
+            const results = await nodeConnection.execute(getNodeIdQuery);
+            const rows = await results.getRows();
+
+            // the connected node should be the same one as specified when opening the connection
+            (rows.length).should.be.eql(1);
+            (rows[0]["[GETNODEID]"]).should.be.eql(n.ID);
+
+            await nodeConnection.close();
+          } catch (e) {
+            console.log(e);
+            err = e;
+          }
+          should.not.exist(err);
+        })
+    );
+  });
+});

--- a/test/13.resultSet.js
+++ b/test/13.resultSet.js
@@ -1,0 +1,64 @@
+// Copyright (c) 2018-2019, NuoDB, Inc.
+// All rights reserved.
+//
+// Redistribution and use permitted under the terms of the 3-clause BSD license.
+
+'use strict';
+
+var { Driver } = require('..');
+
+var should = require('should');
+var config = require('./config');
+var helper = require('./typeHelper');
+
+const tableName = 'TEST_RESULTSET';
+const tableType = 'INTEGER';
+const createTable = helper.sqlCreateTable(tableName,tableType);
+const dropTable = helper.sqlDropTable(tableName);
+
+const tableQuery = `SELECT * FROM ${tableName}`;
+const numRows = 1000;
+const getChunkSize = 50;
+
+
+describe('13. Test Result Set', () => {
+
+  var driver = null;
+  var connection = null;
+
+  before('open connection, init tables', async () => {
+    driver = new Driver();
+    connection = await driver.connect(config);
+    connection.should.be.ok();
+
+    await connection.execute(createTable);
+
+    // insert all the data
+    for(let i = 0; i < numRows; i++){
+      await connection.execute(helper.sqlInsert(tableName), [i]);
+    }
+  });
+
+  after('close connection', async () => {
+    await connection.execute(dropTable);
+    await connection.close();
+  });
+
+  it('13.1 Can get results in chunks', async () => {
+    let err = null;
+    try {
+      const results = await connection.execute(tableQuery);
+      for(let i = 0; i < numRows; i+=getChunkSize){
+        const rows = await results.getRows(getChunkSize);
+        (rows.length).should.be.eql(getChunkSize);
+        (rows[getChunkSize-1]['F1']).should.be.eql(i);
+      }
+    } catch (e) {
+      err = e;
+    }
+
+    should.not.exist(err);
+  });
+
+
+});

--- a/test/8.queryTimeout.js
+++ b/test/8.queryTimeout.js
@@ -1,0 +1,54 @@
+// Copyright (c) 2018-2019, NuoDB, Inc.
+// All rights reserved.
+//
+// Redistribution and use permitted under the terms of the 3-clause BSD license.
+
+'use strict';
+
+var { Driver } = require('..');
+
+var should = require('should');
+var config = require('./config.js');
+
+describe('8. testing query timeout', () => {
+
+  let driver = new Driver();
+  let connection = null;
+
+  before('create driver', async () => {
+    connection = await driver.connect(config);
+  });
+
+  after('close connection', async () => {
+    await connection.close();
+  });
+
+  it('8.1 Query should timeout when expected', async () => {
+    let e = null;
+    try {
+      const result = await connection.execute("select msleep(10000) from dual", {queryTimeout: 1});
+      result.should.be.ok();
+      // ensure that we are actually waiting for the results
+      const row = await result.getRows();
+      row.should.be.ok();
+    } catch (err) {
+      e = err
+    }
+    should.exist(e);
+  });
+
+  it('8.2 Query should not timeout when not expected', async () => {
+    let e = null;
+    try {
+      const result = await connection.execute("select msleep(1) from dual", {queryTimeout:10000});
+      result.should.be.ok();
+      // ensure that we are actually waiting for the results
+      const row = await result.getRows();
+      row.should.be.ok();
+    } catch (err) {
+      e = err
+    }
+    should.not.exist(e);
+  });
+
+});

--- a/test/9.storedProcedures.js
+++ b/test/9.storedProcedures.js
@@ -1,0 +1,80 @@
+// Copyright (c) 2018-2019, NuoDB, Inc.
+// All rights reserved.
+//
+// Redistribution and use permitted under the terms of the 3-clause BSD license.
+
+'use strict';
+
+var { Driver } = require('..');
+
+var should = require('should');
+var config = require('./config.js');
+
+const sprocCreate = `
+  CREATE OR REPLACE PROCEDURE DUMMY_PROCEDURE (in_number INT)
+  AS
+      CREATE TABLE IF NOT EXISTS PROCEDURE_TEST (F1 INT);
+      INSERT INTO PROCEDURE_TEST VALUES (in_number);
+  END_PROCEDURE
+`;
+const sprocDrop = `
+  DROP PROCEDURE IF EXISTS DUMMY_PROCEDURE;
+`;
+const sprocCall = `CALL DUMMY_PROCEDURE(1)`;
+
+const checkProcedure = `SELECT * FROM SYSTEM.PROCEDURES WHERE PROCEDURENAME = 'DUMMY_PROCEDURE'`;
+const checkRan = `SELECT * FROM PROCEDURE_TEST`;
+
+const dropTestTable = `DROP TABLE PROCEDURE_TEST`;
+
+describe('9. testing stored procedures', () => {
+
+  var driver = null;
+  var connection = null;
+
+  before('open connection', async () => {
+    driver = new Driver();
+    connection = await driver.connect(config);
+    connection.should.be.ok();
+  });
+
+  after('close connection', async () => {
+    await connection.execute(dropTestTable);
+    await connection.close();
+  });
+
+  it('9.1 can create a stored procedure', async () => {
+    let err = null;
+    try {
+      await connection.execute(sprocCreate);
+    } catch (e) {
+      err = e
+    }
+    should.not.exist(err)
+
+    const results = await connection.execute(checkProcedure);
+    results.should.be.ok();
+
+    const rows = await results.getRows();
+    (rows.length).should.be.eql(1);
+  });
+
+  it('9.2 can run a stored procedure', async () => {
+    await connection.execute(sprocCall);
+    const results = await connection.execute(checkRan);
+    results.should.be.ok();
+
+    const rows = await results.getRows();
+    (rows.length).should.be.eql(1);
+  });
+
+  it('9.3 can drop a stored procedure', async () => {
+    await connection.execute(sprocDrop);
+    const results = await connection.execute(checkProcedure);
+    results.should.be.ok();
+
+    const rows = await results.getRows();
+    (rows.length).should.be.eql(0);
+  });
+
+});

--- a/test/typeTestCases.js
+++ b/test/typeTestCases.js
@@ -60,10 +60,12 @@ const testCases = [
     data: [
       "1234",
       "abcd",
+      null,
     ],
     checkResults: (rows) => {
       (rows).should.containEql({F1:'31323334'});
       (rows).should.containEql({F1:'61626364'});
+      (rows).should.containEql({F1: null});
     }
   },
   {


### PR DESCRIPTION
- Added a test for callback style syntax
- Added a test for using stored procedures
- Added a test for query timeout
- Added functionality to nan layer to support the use of query timeout
- Fixed a bug which threw "Error: failed to get more result set rows [basic_string::_M_construct null not valid" when reading null values from an XLOB column in a result set
- Added an additional test case to the BLOB test cases for null value

With this PR, we should be able to safely stop using the 4.0 client package when using a 4.3 database. There is a fatal bug when using query timeout with the 4.0 client package. When attempting to get a result set from a query that has timed out the following error is thrown (it appears to be thrown at a lower level than I am able to catch in the nan layer. I did not do a full RCA on it to see exactly what is going on, as the problem is only apparent in the unsupported 4.0 client package)

```
terminate called after thorinwg an instance of 'SQLEngine::SQLError'
Aborted (core dumped)
```