### PR TITLE
Ecoombes/qa issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "NuoDB, Inc.",
   "description": "The official NuoDB driver for Node.js. Provides a high-level SQL API on top of the NuoDB Node.js Addon.",
   "license": "Apache-2.0",
-  "version": "3.1.0",
+  "version": "3.1.2",
   "main": "index.js",
   "keywords": [
     "nuodb",

--- a/test/13.resultSet.js
+++ b/test/13.resultSet.js
@@ -5,6 +5,8 @@
 
 'use strict';
 
+const RESULT_SET_TEST_TIMEOUT = 50000;
+
 var { Driver } = require('..');
 
 var should = require('should');
@@ -61,4 +63,4 @@ describe('13. Test Result Set', () => {
   });
 
 
-});
+}).timeout(RESULT_SET_TEST_TIMEOUT);

--- a/test/typeTestCases.js
+++ b/test/typeTestCases.js
@@ -244,7 +244,15 @@ const testCases = [
     ],
     checkResults: (rows) => {
       for (var time of rows){
-        should.equal(time["F1"].toLocaleTimeString(), '11:11:00 PM')
+        const dateObj = time["F1"];
+        /**
+         * Time is written and read from the db in local time (and interpretted as such by node).
+         * using toLocaleString causes time zone formatting differences between regions
+         * using toISOString will cause differences between time zones as different regions 11:11 PM is a different time in UTC
+         * Comparing the raw hours/minutes will allow us to keep the result of this test consistent across time zones.
+        */
+        should.equal(dateObj.getHours(),23);
+        should.equal(dateObj.getMinutes(),11);
       }
     }
 


### PR DESCRIPTION
This PR should resolve issues [25](https://github.com/nuodb/node-nuodb/issues/25) and [26](https://github.com/nuodb/node-nuodb/issues/26)

The timeout for a specific test which makes several back to back requests to the database has been increased. The test passes locally on multiple machines, but fails in QA. I suspect the problem is just the QA machine is a little slow.

The TIME type test has been modified so that it should perform the same regardless of the timezone / locale it is run in.