### PR TITLE
Ecoombes/driver bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "NuoDB, Inc.",
   "description": "The official NuoDB driver for Node.js. Provides a high-level SQL API on top of the NuoDB Node.js Addon.",
   "license": "Apache-2.0",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "main": "index.js",
   "keywords": [
     "nuodb",

--- a/src/NuoJsTypes.cpp
+++ b/src/NuoJsTypes.cpp
@@ -24,6 +24,10 @@ int typeOf(Local<Value> v)
         // This test has to come before IsObject because IsExternal
         // implies IsObject
         return ES_EXTERNAL;
+    } else if (v->IsDate()) {
+        // This test has to come before IsObject because IsDate
+        // implies IsObject
+        return ES_DATE;
     } else if (v->IsObject()) {
         return ES_OBJECT;
     } else if (v->IsBoolean()) {
@@ -66,9 +70,12 @@ int Type::reduceSqlType(int type)
             return NUOSQL_VARCHAR;
             break;
 
-        // NUOSQL_DATE:
-        // NUOSQL_TIME:
-        // NUOSQL_TIMESTAMP:
+        case NUOSQL_DATE:
+        case NUOSQL_TIME:
+        case NUOSQL_TIMESTAMP:
+            return NUOSQL_DATE;
+            break;
+
         // NUOSQL_BLOB:
         // NUOSQL_CLOB:
         // NUOSQL_NUMERIC:
@@ -103,6 +110,10 @@ int Type::toEsType(int type)
             return EsType::ES_BOOLEAN;
             break;
 
+        case NUOSQL_DATE:
+            return EsType::ES_DATE;
+            break;
+
         default:
             return EsType::ES_UNDEFINED;
     }
@@ -125,6 +136,10 @@ int Type::fromEsType(int type)
 
         case EsType::ES_BOOLEAN:
             return NUOSQL_BOOLEAN;
+            break;
+
+        case EsType::ES_DATE:
+            return NUOSQL_DATE;
             break;
 
         default:

--- a/src/NuoJsTypes.h
+++ b/src/NuoJsTypes.h
@@ -30,6 +30,7 @@ enum EsType
     ES_STRING,
     ES_SYMBOL,
     ES_OBJECT,
+    ES_DATE,
     ES_FUNCTION,
     ES_EXTERNAL,
 };

--- a/test/13.resultSet.js
+++ b/test/13.resultSet.js
@@ -13,16 +13,23 @@ var should = require('should');
 var config = require('./config');
 var helper = require('./typeHelper');
 
-const tableName = 'TEST_RESULTSET';
-const tableType = 'INTEGER';
-const createTable = helper.sqlCreateTable(tableName,tableType);
-const dropTable = helper.sqlDropTable(tableName);
+// constants for 13.1
+const tableNameChunk = 'TEST_RESULTSET';
+const tableTypeChunk = 'INTEGER';
+const createTableChunk = helper.sqlCreateTable(tableNameChunk,tableTypeChunk);
+const dropTableChunk = helper.sqlDropTable(tableNameChunk);
 
-const tableQuery = `SELECT * FROM ${tableName}`;
-const numRows = 1000;
+const tableQueryChunk = `SELECT * FROM ${tableNameChunk}`;
+const numRowsChunk = 1000;
 const getChunkSize = 50;
 
-
+// constants for 13.2
+const createJoinableTables = (t) => `create table test_result_set_${t} (id int, ${t} int)`
+const dropJoinableTables = (t) => `drop table test_result_set_${t}`
+const getJoinableTableInsert = (t,i,v) => `insert into test_result_set_${t} values (${i},${v})`
+const selectFromJoinableTables = (a,b) => `select * from test_result_set_${a} as ta inner join test_result_set_${b} as tb on ta.id=tb.id`
+const selectAliasFromJoinableTables = (a,b) => `select a.id as aid, a.a, b.id as bid, b.b from test_result_set_${a} as a , test_result_set_${b} as b`
+const joinableTablesLength = 5;
 describe('13. Test Result Set', () => {
 
   var driver = null;
@@ -33,24 +40,35 @@ describe('13. Test Result Set', () => {
     connection = await driver.connect(config);
     connection.should.be.ok();
 
-    await connection.execute(createTable);
-
+    // for 13.1 Can get results in chunks
+    await connection.execute(createTableChunk);
     // insert all the data
-    for(let i = 0; i < numRows; i++){
-      await connection.execute(helper.sqlInsert(tableName), [i]);
+    for(let i = 0; i < numRowsChunk; i++){
+      await connection.execute(helper.sqlInsert(tableNameChunk), [i]);
+    }
+
+    // for 13.2 Can get multiple columns with same name in a join
+    await connection.execute(createJoinableTables('a'));
+    await connection.execute(createJoinableTables('b'));
+    for(let i = 0; i < joinableTablesLength; i++){
+      await connection.execute(getJoinableTableInsert('a',i,0));
+      await connection.execute(getJoinableTableInsert('b',i,1));
     }
   });
 
   after('close connection', async () => {
-    await connection.execute(dropTable);
+    console.log("after");
+    await connection.execute(dropTableChunk);
+    await connection.execute(dropJoinableTables('a'));
+    await connection.execute(dropJoinableTables('b'));
     await connection.close();
   });
 
   it('13.1 Can get results in chunks', async () => {
     let err = null;
     try {
-      const results = await connection.execute(tableQuery);
-      for(let i = 0; i < numRows; i+=getChunkSize){
+      const results = await connection.execute(tableQueryChunk);
+      for(let i = 0; i < numRowsChunk; i+=getChunkSize){
         const rows = await results.getRows(getChunkSize);
         (rows.length).should.be.eql(getChunkSize);
         (rows[getChunkSize-1]['F1']).should.be.eql(i);
@@ -62,5 +80,38 @@ describe('13. Test Result Set', () => {
     should.not.exist(err);
   });
 
+  it('13.2 Can get full result set from tables with duplicate column name', async () => {
+    let err = null;
+    try {
+      console.log("13.2");
+      const results = await connection.execute(selectFromJoinableTables('a','b'), {rowMode:0});
+      const rows = await results.getRows();
+      console.log(rows);
+      const columns = Object.keys(rows[0]);
+      (columns.length).should.be.eql(4);
+    } catch (e) {
+      err = e;
+    }
+
+    should.not.exist(err);
+  });
+
+  it('13.3 Can alias a column label', async () => {
+    let err = null;
+    try {
+      console.log("13.2");
+      const results = await connection.execute(selectAliasFromJoinableTables('a','b'));
+      const rows = await results.getRows();
+      const columns = Object.keys(rows[0]);
+      (columns.length).should.be.eql(4);
+      columns.should.containEql('AID');
+      columns.should.containEql('BID');
+    } catch (e) {
+      err = e;
+    }
+
+    should.not.exist(err);
+
+  });
 
 }).timeout(RESULT_SET_TEST_TIMEOUT);

--- a/test/7.typeTests.js
+++ b/test/7.typeTests.js
@@ -31,14 +31,20 @@ describe('7. testing types', async () => {
     const {data,type} = curr;
     // use specified table name for test if exists, otherwise determine programatically by type
     const tableName = curr.tableName ?? `table_${type}`;
+    const tableCreate = curr.tableCreate ?? helper.sqlCreateTable(tableName, type);
+    const testDescription = curr.description ?? `type ${type}`;
 
-    describe(`7.${index} Testing ${type}`, () => {
+    describe(`7.${index} Testing ${testDescription}`, () => {
 
       before(`create ${type} table, insert data`, async () => {
         await connection.execute(helper.sqlDropTable(tableName));
-        await connection.execute(helper.sqlCreateTable(tableName,type));
+        await connection.execute(tableCreate);
         await async.series(data.map((d) => async () => {
-          await connection.execute(helper.sqlInsert(tableName),[d]);
+          if(curr.tableInsert != undefined){
+            await connection.execute(curr.tableInsert, d);
+          } else {
+            await connection.execute(helper.sqlInsert(tableName),[d]);
+          }
         }))
       });
 
@@ -47,7 +53,7 @@ describe('7. testing types', async () => {
       });
 
       it(`7.${index} result set stores ${type} correctly`, async () => {
-        const results = await connection.execute("SELECT * FROM " + tableName);
+        const results = await connection.execute("SELECT F1 FROM " + tableName);
         results.should.be.ok();
 
         const rows = await results.getRows();

--- a/test/typeTestCases.js
+++ b/test/typeTestCases.js
@@ -99,6 +99,39 @@ const testCases = [
     }
   },
   {
+    type: 'STRING',
+    description: 'undefined does not convert to string "undefined"',
+    tableName: 'undefined_string',
+    data: [
+      undefined,
+      "",
+      "hello world",
+    ],
+    checkResults: (rows) => {
+      (rows).should.containEql({F1:"hello world"});
+      (rows).should.containEql({F1:""});
+      (rows).should.containEql({F1: null});
+      (rows).should.not.containEql({F1:'undefined'});
+      (rows).should.not.containEql({F1:'UNDEFINED'});
+    }
+  },
+  {
+    type: 'STRING',
+    tableName: 'undefined_string_default',
+    tableCreate: "create table if not exists undefined_string_default (F2 int, F1 STRING default 'default')",
+    tableInsert: "insert into undefined_string_default (F2) values (?)",
+    description: "undefined converts to default value",
+    data: [
+      [0],
+    ],
+    checkResults: (rows) => {
+      (rows).should.containEql({F1: "default"});
+      (rows).should.not.containEql({F1:null});
+      (rows).should.not.containEql({F1:'undefined'});
+      (rows).should.not.containEql({F1:'UNDEFINED'});
+    }
+  },
+  {
     type: 'BOOLEAN',
     data:[
       0,
@@ -198,8 +231,9 @@ const testCases = [
       new Date('1995-12-17T03:24:00'),
       new Date('2015-07-23 21:00:00'),
       new Date('2015-07-23 22:00:00'),
-      new Date('2015-07-23 23:00:00'),
-      new Date('2015-07-24 00:00:00'),
+      new Date('2015-07-23 23:00:00.789123'),
+      new Date('2015-07-24 00:00:00.456789'),
+      new Date('2015-07-23 12:34:56.123456'),
     ],
     checkResults: (rows) => {
       (rows).should.containEql({F1: new Date(-100000000)});
@@ -210,8 +244,9 @@ const testCases = [
       (rows).should.containEql({F1: new Date('1995-12-17T03:24:00')});
       (rows).should.containEql({F1: new Date('2015-07-23 21:00:00')});
       (rows).should.containEql({F1: new Date('2015-07-23 22:00:00')});
-      (rows).should.containEql({F1: new Date('2015-07-23 23:00:00')});
-      (rows).should.containEql({F1: new Date('2015-07-24 00:00:00')});
+      (rows).should.containEql({F1: new Date('2015-07-23 23:00:00.789123')});
+      (rows).should.containEql({F1: new Date('2015-07-24 00:00:00.456789')});
+      (rows).should.containEql({F1: new Date('2015-07-23 12:34:56.123456')});
     }
   },
   {


### PR DESCRIPTION
- `ES_UNDEFINED` is now treated in the same manner as `ES_NULL`. (Resolving `ES_UNDEFINED` -> 'undefined' string bug)
- `ES_DATE` handling has been improved, no longer tracked under the umbrella of `ES_UNDEFINED`.
- Insertion of an `ES_DATE` type data now tracks milliseconds.
- Resolved bug where aliased columns in a `ResultSet` used their column name, rather than aliased label, as the object attribute for their resulting row objects in the node layer.
- Updated version in package.json to 3.2.1