### PR TITLE
Ecoombes/timeout patch

### DIFF
--- a/src/NuoJsOptions.cpp
+++ b/src/NuoJsOptions.cpp
@@ -14,11 +14,12 @@ namespace NuoJs
 const uint32_t CONSISTENT_READ = 7;
 
 Options::Options()
-    : rowMode(ROWS_AS_OBJECT), fetchSize(0), isolationLevel(CONSISTENT_READ), autoCommit(true), readOnly(false)
+    // defaults for all statement options
+    : rowMode(ROWS_AS_OBJECT), fetchSize(0), isolationLevel(CONSISTENT_READ), autoCommit(true), readOnly(false), queryTimeout(0)
 {}
 
 Options::Options(const Options& options)
-    : rowMode(options.rowMode), fetchSize(options.fetchSize), autoCommit(options.autoCommit), readOnly(options.readOnly)
+    : rowMode(options.rowMode), fetchSize(options.fetchSize), autoCommit(options.autoCommit), readOnly(options.readOnly), queryTimeout(options.queryTimeout)
 {}
 
 Options& Options::operator=(const Options& options)
@@ -27,6 +28,7 @@ Options& Options::operator=(const Options& options)
     this->fetchSize = options.fetchSize;
     this->autoCommit = options.autoCommit;
     this->readOnly = options.readOnly;
+    this->queryTimeout = options.queryTimeout;
     return *this;
 }
 


### PR DESCRIPTION
Three simple changes:
1. Add default for query timeout in src/NuoJsOptions.cpp -- this will prevent any potential bugs arising from junk data that would otherwise have been loaded into the space where the query timeout option was stored when queryTimeout was not set.
2. Refactor tests to use args with a query, as well as query options. This increases code coverage as the NAN layer has a few additional blocks of code that are run when args are present.
3. Add an additional test case to the query timeout tests to ensure that the app layer is unable to cause a query timeout.