### PR TITLE
Prosenberg/lazy close

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -98,7 +98,7 @@ class Pool {
     }
     this.livelinessStatus = Pool.LIVELINESS_NOT_RUNNING;
   }
-
+  //! this will get a bit slower with the change with lazyClose as there will be possibly much larger pools, significant?
   _checkFreeAndRemove(_id) {
     for (let i = 0; i < this.free_connections.length; i++) {
       if (this.free_connections[i]._id === _id) {
@@ -261,6 +261,7 @@ class Pool {
       return;
     }
     // if returned connection will bring us over our desired # of connections, close it
+    //! can just add a setting "lazyClose" that when true triggers the below if statement, ignores if false
     if (this.free_connections.length >= this.config.minAvailable) {
       clearTimeout(this.all_connections[connection._id].ageOutID);
       delete this.all_connections[connection._id];

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -260,19 +260,7 @@ class Pool {
       }
       return;
     }
-    // if returned connection will bring us over our desired # of connections, close it
-    //! can just add a setting "lazyClose" that when true triggers the below if statement, ignores if false
-    // if (this.free_connections.length >= this.config.minAvailable) {
-    //   clearTimeout(this.all_connections[connection._id].ageOutID);
-    //   delete this.all_connections[connection._id];
-    //   try {
-    //     await connection._defaultClose();
-    //   } catch (e) {
-    //      continue regardless of error
-    //   }
-    //   return;
-    // }
-    // connection is not aged out and connection limit not reached
+    // if returned connection will bring us over our desired # of connections, close it REMOVED
     const connectionAlive = await this._checkConnection(connection); //returns boolean
     if (connectionAlive) {
       this.all_connections[connection._id].inUse = false;
@@ -302,4 +290,3 @@ class Pool {
 }
 
 module.exports = Pool;
-//? Should we reset age outs when a connection returns to pool when aging out during use.

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -98,7 +98,7 @@ class Pool {
     }
     this.livelinessStatus = Pool.LIVELINESS_NOT_RUNNING;
   }
-  //! this will get a bit slower with the change with lazyClose as there will be possibly much larger pools, significant?
+
   _checkFreeAndRemove(_id) {
     for (let i = 0; i < this.free_connections.length; i++) {
       if (this.free_connections[i]._id === _id) {
@@ -262,16 +262,16 @@ class Pool {
     }
     // if returned connection will bring us over our desired # of connections, close it
     //! can just add a setting "lazyClose" that when true triggers the below if statement, ignores if false
-    if (this.free_connections.length >= this.config.minAvailable) {
-      clearTimeout(this.all_connections[connection._id].ageOutID);
-      delete this.all_connections[connection._id];
-      try {
-        await connection._defaultClose();
-      } catch (e) {
-        // continue regardless of error
-      }
-      return;
-    }
+    // if (this.free_connections.length >= this.config.minAvailable) {
+    //   clearTimeout(this.all_connections[connection._id].ageOutID);
+    //   delete this.all_connections[connection._id];
+    //   try {
+    //     await connection._defaultClose();
+    //   } catch (e) {
+    //      continue regardless of error
+    //   }
+    //   return;
+    // }
     // connection is not aged out and connection limit not reached
     const connectionAlive = await this._checkConnection(connection); //returns boolean
     if (connectionAlive) {
@@ -302,3 +302,4 @@ class Pool {
 }
 
 module.exports = Pool;
+//? Should we reset age outs when a connection returns to pool when aging out during use.

--- a/test/21.pooling.js
+++ b/test/21.pooling.js
@@ -161,7 +161,7 @@ describe("14 test pooling", () => {
     await connection.close();
     should.equal(
       pool.free_connections.length,
-      11,
+      12,
       "calling close on the connection should return it to the pool"
     );
   });

--- a/test/21.pooling.js
+++ b/test/21.pooling.js
@@ -78,7 +78,7 @@ describe("14 test pooling", () => {
     );
   });
 
-  it("14.5 Allows users to request over soft limit of connections and closes excess connections upon return", async () => {
+  it("14.5 Allows users to request over soft limit of connections", async () => {
     connections = [];
     for (let i = 0; i < 11; i++) {
       connections.push(await pool.requestConnection());
@@ -94,7 +94,7 @@ describe("14 test pooling", () => {
     }
     should.equal(
       pool.free_connections.length,
-      10,
+      11,
       "pool should remain with 10 free connections when none are in use"
     );
   });
@@ -155,13 +155,13 @@ describe("14 test pooling", () => {
     const connection = await pool.requestConnection();
     should.equal(
       pool.free_connections.length,
-      9,
-      "pool should have 9 connections"
+      11,
+      "pool should have 11 connections"
     );
     await connection.close();
     should.equal(
       pool.free_connections.length,
-      10,
+      11,
       "calling close on the connection should return it to the pool"
     );
   });


### PR DESCRIPTION
This change makes the pool no longer eagerly close connections when they are returned to the pool and we have more than minAvailable connections in free_connections. Now connections are only closed when they age out or are found to longer be functioning.