### PR TITLE
Changes to avoid useless Connection Property setting calls and an equ…

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "NuoDB, Inc.",
   "description": "The official NuoDB driver for Node.js. Provides a high-level SQL API on top of the NuoDB Node.js Addon.",
   "license": "Apache-2.0",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "main": "index.js",
   "keywords": [
     "nuodb",
@@ -24,14 +24,14 @@
   "gypfile": true,
   "dependencies": {
     "bindings": "^1.5.0",
-    "nan": "^2.15.0",
+    "nan": "^2.16.0",
     "node-gyp": "^8.4.1",
     "segfault-handler": "^1.3.0"
   },
   "devDependencies": {
     "async": "^3.2.3",
     "eslint": "^8.6.0",
-    "mocha": "^9.1.3",
+    "mocha": "^9.2.2",
     "okay": "^1.0.0",
     "should": "^13.2.3"
   },

--- a/src/NuoJsConnection.h
+++ b/src/NuoJsConnection.h
@@ -24,8 +24,17 @@ public:
 
     static Nan::Persistent<Function> constructor;
 
+    static unsigned int getRestrictedAPI();
+    static void setRestrictedAPI(unsigned int);
+    static unsigned int Restricted_API(const std::string&);
+
+    bool _AutoCommit = true;
+    bool _ReadOnly = false;
+    uint32_t _IsolationLevel = 7;
+
 private:
 
+    static unsigned int restrictedAPI;
     static NAN_METHOD(execute);
     friend class ExecuteWorker;
     bool doExecute(NuoDB::PreparedStatement* statement);

--- a/src/NuoJsOptions.cpp
+++ b/src/NuoJsOptions.cpp
@@ -8,6 +8,7 @@
 #include "NuoJsJson.h"
 
 #include <stdio.h>
+#include <iostream>
 
 namespace NuoJs
 {
@@ -30,6 +31,14 @@ Options& Options::operator=(const Options& options)
     this->readOnly = options.readOnly;
     this->queryTimeout = options.queryTimeout;
     return *this;
+}
+
+bool Options::operator==(const Options& rhs) const {
+	return (rowMode == rhs.rowMode) &&
+	       (fetchSize == rhs.fetchSize) &&
+	       (isolationLevel == rhs.isolationLevel) &&
+	       (autoCommit == rhs.autoCommit) &&
+	       (readOnly == rhs.readOnly);
 }
 
 RowMode Options::getRowMode() const

--- a/src/NuoJsOptions.h
+++ b/src/NuoJsOptions.h
@@ -19,6 +19,8 @@ public:
     Options();
     Options(const Options& options);
     Options& operator=(const Options& options);
+    bool operator==(const Options& rhs) const;
+
 
     RowMode getRowMode() const;
     void setRowMode(RowMode);


### PR DESCRIPTION
The state of this code is intended to allow 3DMessage Team to validate if they are not making these property setting calls on Connections, we see some form of improved throughput, effectively making query execution faster, which may or may not help the bottlenecks over all.  It did help throughput for the driver stress test.

The basic premise is to allow the user of the driver to set an environment variable, with particular values that will turn off the execution of calling API to set properties if it is believed the value already is use is the same.  Since the default is to allow the code to execute as usual when the environment setting is not made, then the driver should function as it does before these changes.