### PR TITLE
These changes alter the manner database connectivity is expressed.  I…

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "NuoDB, Inc.",
   "description": "The official NuoDB driver for Node.js. Provides a high-level SQL API on top of the NuoDB Node.js Addon.",
   "license": "Apache-2.0",
-  "version": "3.3.1",
+  "version": "3.4",
   "main": "index.js",
   "keywords": [
     "nuodb",

--- a/src/NuoJsParams.cpp
+++ b/src/NuoJsParams.cpp
@@ -64,10 +64,11 @@ std::string getConnectionString(Params& params)
 {
     try {
         checkParam(params, "database");
-        checkParam(params, "hostname");
-        checkParam(params, "port");
+        //checkParam(params, "hostname");
+        //checkParam(params, "port");
         std::ostringstream connection_string;
-        connection_string << params["database"] << "@" << params["hostname"] << ":" << params["port"];
+        //connection_string << params["database"] << "@" << params["hostname"] << ":" << params["port"];
+        connection_string << params["database"];
         return connection_string.str();
     } catch (NuoDB::SQLException& e) {
         throw std::runtime_error(e.getText());

--- a/test/config.js
+++ b/test/config.js
@@ -5,9 +5,7 @@
 
 var config = {};
 
-config.database = 'test';
-config.hostname = 'localhost';
-config.port = 48004;
+config.database = 'test@nuordcbig05:48004,test@nuordcbig02:48004';
 config.user = 'dba';
 config.password = 'dba';
 config.schema = 'USER';


### PR DESCRIPTION
Instead of connection properties for hostname and port to be singularly expressed, just support a database list that allows for multiple comma separated expressions of database[@hostname[:port]] entries.  The code will now just pass the string expression down to the underlying C++ driver for all resolution.