### PR TITLE
Fix mistake in checkTime

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -29,7 +29,7 @@ class Pool {
       minAvailable: args.minAvailable || 10,
       connectionConfig: args.connectionConfig,
       maxAge: args.maxAge || 300000,
-      checkTime: args.checkTime || 120000, // how often to run the livliness check, will not run when set to 0
+      checkTime: args.checkTime ?? 120000, // how often to run the livliness check, will not run when set to 0
       maxLimit: args.maxLimit ?? 200,
       connectionRetryLimit: args.connectionRetryLimit || 5,
     };


### PR DESCRIPTION
Changed checkTime from Logical Or(||) to Nullish Coalescing Operator(??) to enable the ability to pass 0 as argument and cancel liveliness check.