### PR TITLE
changes made to fix undesired autocommit toggling and allow livelines…

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ The NuoDB Node.js driver comes with a built in connection pool available.
 
 **id:** optional argument to give the pool an id. As default the pool will be provided the “new Date().getTime()” at the time of its creation as its id.
 
+**skipCheckLivelinessOnRelease:** turns off liveliness checks on connections when they are released back to the pool, which is different than the checkTime that is used for aging purposes.  The default is false, meaning we will perform a liveliness check when a connection is returned to the pool.
+
+**livelinessCheck:** indicates the type of liveliness check to be performed.  By default, the value is set to query, which means a query to test the connection.  If set to any other value other than query, it will only look to see if the NuoDB API isConnected returns true and we have not trapped a connection related exception previously.
+
 Arguments should be provided to the pool as an object. Please refer to the Usage section for an example.
 
 ### Usage

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The NuoDB Node.js driver comes with a built in connection pool available.
 
 **skipCheckLivelinessOnRelease:** turns off liveliness checks on connections when they are released back to the pool, which is different than the checkTime that is used for aging purposes.  The default is false, meaning we will perform a liveliness check when a connection is returned to the pool.
 
-**livelinessCheck:** indicates the type of liveliness check to be performed.  By default, the value is set to query, which means a query to test the connection.  If set to any other value other than query, it will only look to see if the NuoDB API isConnected returns true and we have not trapped a connection related exception previously.
+**livelinessCheck:** indicates the type of liveliness check to be performed.  By default, the value is set to query, which means a query to test the connection.  If set to any value other than query, it will only look to see if the NuoDB API isConnected returns true and we have not trapped a connection related exception previously.
 
 Arguments should be provided to the pool as an object. Please refer to the Usage section for an example.
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -107,7 +107,7 @@ function extend(connection, driver) {
         value: executePromisified,
         enumerable: true,
         writable: true
-      }
+      },
     }
   );
 }

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -32,6 +32,8 @@ class Pool {
       checkTime: args.checkTime ?? 120000, // how often to run the livliness check, will not run when set to 0
       maxLimit: args.maxLimit ?? 200,
       connectionRetryLimit: args.connectionRetryLimit || 5,
+      skipCheckLivelinessOnRelease : args.skipCheckLivelinessOnRelease ?? false,
+      livelinessCheck: args.livelinessCheck ?? 'query'
     };
     this.poolId = args.id || new Date().getTime();
 
@@ -69,14 +71,31 @@ class Pool {
     }
     return connection === this.all_connections[connection._id].connection;
   }
-  //check connection is alive
+  // check connection is alive
+  // First check if a liveliness check is desired and if so
+  // check at least the connection believed to be connenected
+  // and if indicated to full check by running a query
+  // if any of the desired checks show a problem return false,
+  // indicating the connection is a problem, otherwise return true
   async _checkConnection(connection) {
-    try {
-      await connection.execute("SELECT 1 AS VALUE FROM DUAL");
-    } catch (e) {
-      return false;
+    let retvalue = true;
+    if (this.config.skipCheckLivelinessOnRelease === false) {
+      if (connection.hasFailed() === false) {
+        if (this.config.livelinessCheck.toLowerCase() === 'query') {
+          try {
+            const result = await connection.execute("SELECT 1 AS VALUE FROM DUAL");
+            await result.close();
+          } catch (e) {
+            retvalue = false;
+          }
+        }
+      } else {
+        retvalue = false;
+      }
     }
-    return true;
+    // if we get here it means either we want all connections put back in the pool or any of liveliness check
+    // performed, either a connection check or a full query all passed
+    return retvalue;
   }
   //connection will be checked when releaseConnection is called on it.
   async _livelinessCheck() {
@@ -262,7 +281,8 @@ class Pool {
       }
       return;
     }
-    // if returned connection will bring us over our desired # of connections, close it REMOVED
+    // Determine if the connection has any problem to avoid keeping and returning a bad
+    // connection to the pool
     const connectionAlive = await this._checkConnection(connection); //returns boolean
     if (connectionAlive) {
       this.all_connections[connection._id].inUse = false;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,23 @@
 {
   "name": "node-nuodb",
-  "version": "3.0.0",
+  "version": "3.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-nuodb",
-      "version": "3.0.0",
+      "version": "3.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "bindings": "^1.5.0",
-        "nan": "^2.15.0",
+        "nan": "^2.17.0",
         "node-gyp": "^8.4.1",
         "segfault-handler": "^1.3.0"
       },
       "devDependencies": {
         "async": "^3.2.3",
         "eslint": "^8.6.0",
-        "mocha": "^9.1.3",
+        "mocha": "^9.2.2",
         "okay": "^1.0.0",
         "should": "^13.2.3"
       },
@@ -1423,9 +1423,9 @@
       }
     },
     "node_modules/mocha": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.0.tgz",
-      "integrity": "sha512-kNn7E8g2SzVcq0a77dkphPsDSN7P+iYkqE0ZsGCYWRsoiKjOt+NvXfaagik8vuDa6W5Zw3qxe8Jfpt5qKf+6/Q==",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
+      "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
       "dev": true,
       "dependencies": {
         "@ungap/promise-all-settled": "1.1.2",
@@ -1441,9 +1441,9 @@
         "he": "1.2.0",
         "js-yaml": "4.1.0",
         "log-symbols": "4.1.0",
-        "minimatch": "3.0.4",
+        "minimatch": "4.2.1",
         "ms": "2.1.3",
-        "nanoid": "3.2.0",
+        "nanoid": "3.3.1",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
@@ -1463,6 +1463,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mochajs"
+      }
+    },
+    "node_modules/mocha/node_modules/minimatch": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
+      "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/mocha/node_modules/ms": {
@@ -1492,14 +1504,14 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/nan": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
     },
     "node_modules/nanoid": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
-      "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
       "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -3360,9 +3372,9 @@
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
     },
     "mocha": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.0.tgz",
-      "integrity": "sha512-kNn7E8g2SzVcq0a77dkphPsDSN7P+iYkqE0ZsGCYWRsoiKjOt+NvXfaagik8vuDa6W5Zw3qxe8Jfpt5qKf+6/Q==",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
+      "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
       "dev": true,
       "requires": {
         "@ungap/promise-all-settled": "1.1.2",
@@ -3378,9 +3390,9 @@
         "he": "1.2.0",
         "js-yaml": "4.1.0",
         "log-symbols": "4.1.0",
-        "minimatch": "3.0.4",
+        "minimatch": "4.2.1",
         "ms": "2.1.3",
-        "nanoid": "3.2.0",
+        "nanoid": "3.3.1",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
@@ -3391,6 +3403,15 @@
         "yargs-unparser": "2.0.0"
       },
       "dependencies": {
+        "minimatch": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
+          "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
         "ms": {
           "version": "2.1.3",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3414,14 +3435,14 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "nan": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
     },
     "nanoid": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
-      "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
       "dev": true
     },
     "natural-compare": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "gypfile": true,
   "dependencies": {
     "bindings": "^1.5.0",
-    "nan": "^2.16.0",
+    "nan": "^2.17.0",
     "node-gyp": "^8.4.1",
     "segfault-handler": "^1.3.0"
   },

--- a/src/NuoJsConnection.cpp
+++ b/src/NuoJsConnection.cpp
@@ -27,6 +27,10 @@ enum API_ID {
 	ISOLATIONLEVEL = (1u << 2),
 };
 
+bool Connection::Default_AutoCommit = true;
+bool Connection::Default_ReadOnly = false;
+uint32_t Connection::Default_IsolationLevel = 7;
+
 // This routine is used to translate the textual name used for an ENUM setting and get
 // the actual bitmask value associated with it
 // 
@@ -67,6 +71,9 @@ Connection::Connection()
     : Nan::ObjectWrap()
 {
     TRACE("Connection::Connection");
+    _AutoCommit = Default_AutoCommit;
+    _ReadOnly = Default_ReadOnly;
+    _IsolationLevel = Default_IsolationLevel;
 }
 
 /* virtual */
@@ -91,6 +98,7 @@ NAN_MODULE_INIT(Connection::init)
     Nan::SetPrototypeMethod(tpl, "commit", commit);
     Nan::SetPrototypeMethod(tpl, "execute", execute),
     Nan::SetPrototypeMethod(tpl, "rollback", rollback);
+    Nan::SetPrototypeMethod(tpl, "hasFailed", hasFailed);
 
     // See: https://medium.com/netscape/tutorial-building-native-c-modules-for-node-js-using-nan-part-1-755b07389c7c
     Nan::SetAccessor(tpl->InstanceTemplate(), Nan::New("autoCommit").ToLocalChecked(),
@@ -473,9 +481,12 @@ NAN_METHOD(Connection::execute)
               return;
           }
       }
-      self->setIsolationLevel(options.getIsolationLevel());
-      self->setAutoCommit(options.getAutoCommit());
-      self->setReadOnly(options.getReadOnly());
+      if ((options.isNonDefault(Options::Option::isolationlevel)) && (self->_IsolationLevel != options.getIsolationLevel())) self->setIsolationLevel(options.getIsolationLevel());
+      if ((options.isNonDefault(Options::Option::autocommit)) && (self->_AutoCommit != options.getAutoCommit())) self->setAutoCommit(options.getAutoCommit());
+      if ((options.isNonDefault(Options::Option::readonly)) && (self->_ReadOnly != options.getReadOnly())) self->setReadOnly(options.getReadOnly());
+//      self->setIsolationLevel(options.getIsolationLevel());
+//      self->setAutoCommit(options.getAutoCommit());
+//      self->setReadOnly(options.getReadOnly());
     } catch (std::exception& e) {
         error = e.what();
     }
@@ -583,6 +594,19 @@ NuoDB::PreparedStatement* Connection::createStatement(std::string sql, Local<Arr
     return statement;
 }
 
+// Look for any error message that should indicate the connection is no longer useable
+// If we find a problem, then save the error message so the Connection is not reused
+void Connection::markForFailure(NuoDB::SQLException& e) {
+	const int code = e.getSqlcode();
+	//const char *ptr1 = strstr(errorText,"Connection reset by peer");
+	//const char *ptr2 = strstr(errorText,"connection closed");
+	if ((code == -7) || 
+	    (code == -10) ||
+            (code == -50)) {
+		failureText = e.getText();
+	}
+}
+
 bool Connection::doExecute(NuoDB::PreparedStatement* statement)
 {
     if (!isConnected()) {
@@ -593,8 +617,36 @@ bool Connection::doExecute(NuoDB::PreparedStatement* statement)
     try {
         return statement->execute();
     } catch (NuoDB::SQLException& e) {
+	// Execution has failed, see if the failure should consider the connection dead
+	markForFailure(e);
         throw std::runtime_error(e.getText());
     }
+}
+
+bool Connection::isFailed() const
+{
+    return !(isConnected() && failureText.empty());
+}
+
+NAN_METHOD(Connection::hasFailed)
+{
+    TRACE("Connection::hasFailed");
+    Nan::HandleScope scope;
+
+    Connection* self = Nan::ObjectWrap::Unwrap<Connection>(info.This());
+
+    info.GetReturnValue().Set(Nan::New<Boolean>(self->isFailed()));
+}
+
+NAN_METHOD(Connection::isConnected)
+{
+    TRACE("Connection::isConnected");
+    std::cout << "NAN_METHOD Connection::isConnected" << std::endl;
+    Nan::HandleScope scope;
+
+    Connection* self = Nan::ObjectWrap::Unwrap<Connection>(info.This());
+
+    info.GetReturnValue().Set(Nan::New<Boolean>(self->isConnected()));
 }
 
 // Get read-only mode synchronously.
@@ -640,7 +692,7 @@ NAN_SETTER(Connection::setReadOnly)
     }
 }
 
-// Get read-only mode synchronously.
+// Get AutoCommit  mode synchronously.
 NAN_GETTER(Connection::getAutoCommit)
 {
     TRACE("Connection::GetAutoCommit");
@@ -657,7 +709,7 @@ NAN_GETTER(Connection::getAutoCommit)
     info.GetReturnValue().Set(Nan::New<Boolean>(self->isAutoCommit()));
 }
 
-// Set read-only mode synchronously.
+// Set AutoCommit mode synchronously.
 NAN_SETTER(Connection::setAutoCommit)
 {
 
@@ -686,7 +738,7 @@ NAN_SETTER(Connection::setAutoCommit)
 
 bool Connection::isConnected() const
 {
-    return connection != nullptr && connection->isConnected();
+    return ((connection != nullptr) && (connection->isConnected()));
 }
 
 bool Connection::isReadOnly() const
@@ -719,7 +771,9 @@ void Connection::setAutoCommit(bool mode)
 	if (((Connection::getRestrictedAPI()&API_ID::AUTOCOMMIT) == 0) || (mode != _AutoCommit)) {
           connection->setAutoCommit(mode);
 	  _AutoCommit = mode;
+	} else {
 	}
+
     }
 }
 

--- a/src/NuoJsConnection.h
+++ b/src/NuoJsConnection.h
@@ -7,12 +7,19 @@
 // Redistribution and use permitted under the terms of the 3-clause BSD license.
 
 #include "NuoJsAddon.h"
+#include "NuoDB.h"
+#include <string>
 
 namespace NuoJs
 {
 class Connection : public Nan::ObjectWrap
 {
 public:
+
+    static bool Default_AutoCommit;
+    static bool Default_ReadOnly;
+    static uint32_t Default_IsolationLevel;
+
     Connection();
     virtual ~Connection();
 
@@ -28,9 +35,14 @@ public:
     static void setRestrictedAPI(unsigned int);
     static unsigned int Restricted_API(const std::string&);
 
-    bool _AutoCommit = true;
-    bool _ReadOnly = false;
-    uint32_t _IsolationLevel = 7;
+    bool _AutoCommit;
+    bool _ReadOnly;
+    uint32_t _IsolationLevel;
+
+    void markForFailure(NuoDB::SQLException& e);
+
+    static NAN_METHOD(hasFailed);
+    bool isFailed() const;
 
 private:
 
@@ -64,9 +76,15 @@ private:
     static NAN_SETTER(setAutoCommit);
     void setAutoCommit(bool mode);
 
+
+    static NAN_METHOD(isConnected);
+    bool isConnected() const;
+
+    //SQLException failure;
+    std::string failureText;
+
     friend class Driver;
 
-    bool isConnected() const;
     void setIsolationLevel(uint32_t isolation);
 
     class NuoDB::Connection* connection;

--- a/src/NuoJsOptions.cpp
+++ b/src/NuoJsOptions.cpp
@@ -16,11 +16,20 @@ const uint32_t CONSISTENT_READ = 7;
 
 Options::Options()
     // defaults for all statement options
-    : rowMode(ROWS_AS_OBJECT), fetchSize(0), isolationLevel(CONSISTENT_READ), autoCommit(true), readOnly(false), queryTimeout(0)
+    : rowMode(ROWS_AS_OBJECT),
+      fetchSize(0),
+      isolationLevel(CONSISTENT_READ),
+      autoCommit(true),
+      readOnly(false),
+      queryTimeout(0)
 {}
 
 Options::Options(const Options& options)
-    : rowMode(options.rowMode), fetchSize(options.fetchSize), autoCommit(options.autoCommit), readOnly(options.readOnly), queryTimeout(options.queryTimeout)
+    : rowMode(options.rowMode),
+      fetchSize(options.fetchSize),
+      autoCommit(options.autoCommit),
+      readOnly(options.readOnly),
+      queryTimeout(options.queryTimeout)
 {}
 
 Options& Options::operator=(const Options& options)
@@ -45,54 +54,78 @@ RowMode Options::getRowMode() const
 {
     return rowMode;
 }
+
 void Options::setRowMode(RowMode v)
 {
-    rowMode = v;
+    if (v != rowMode){
+      setNonDefault(Option::rowmode);
+      rowMode = v;
+    }
 }
 
 uint32_t Options::getFetchSize() const
 {
     return fetchSize;
 }
+
 void Options::setFetchSize(uint32_t v)
 {
-    fetchSize = v;
+    if (v != fetchSize) {
+      setNonDefault(Option::fetchsize);
+      fetchSize = v;
+    }
 }
 
 uint32_t Options::getIsolationLevel() const
 {
     return isolationLevel;
 }
+
 void Options::setIsolationLevel(uint32_t v)
 {
-    isolationLevel = v;
+    if (v != isolationLevel) {
+      setNonDefault(Option::isolationlevel);
+      isolationLevel = v;
+    }
 }
 
 bool Options::getAutoCommit() const
 {
     return autoCommit;
 }
+
 void Options::setAutoCommit(bool v)
 {
-    autoCommit = v;
+    if (v != autoCommit) {
+      setNonDefault(Option::autocommit);
+      autoCommit = v;
+    }
 }
 
 bool Options::getReadOnly() const
 {
     return readOnly;
 }
+
 void Options::setReadOnly(bool v)
 {
-    readOnly = v;
+    if (v != readOnly) {
+      setNonDefault(Option::readonly);
+      readOnly = v;
+    }
 }
 
 uint32_t Options::getQueryTimeout() const
 {
     return queryTimeout;
 }
+
 void Options::setQueryTimeout(uint32_t v)
 {
-    queryTimeout = v;
+    if (v != queryTimeout) {
+      setNonDefault(Option::querytimeout);
+      queryTimeout = v;
+    }
 }
 
 RowMode toRowMode(uint32_t value)
@@ -108,5 +141,23 @@ void getJsonOptions(Local<Object> object, Options& options)
     options.setAutoCommit(getJsonBoolean(object, "autoCommit", options.getAutoCommit()));
     options.setReadOnly(getJsonBoolean(object, "readOnly", options.getReadOnly()));
     options.setQueryTimeout(getJsonUint(object, "queryTimeout", options.getQueryTimeout()));
+}
+
+void Options::setNonDefault(Options::Option bit) 
+{
+	defaults |= 1 << (int) bit;
+}
+
+void Options::unsetNonDefault(Options::Option bit)
+{
+	defaults &= ~(1<<(int)bit);
+}
+
+bool Options::isNonDefault(Options::Option bit)
+{
+	if ((defaults & (1 << (int)bit)) != 0)
+		return true;
+	else
+		return false;
 }
 }

--- a/src/NuoJsOptions.h
+++ b/src/NuoJsOptions.h
@@ -15,6 +15,16 @@ namespace NuoJs
 class Options
 {
 public:
+
+    enum Option {
+	    rowmode = 1,
+	    fetchsize = 2,
+	    isolationlevel = 3,
+	    autocommit = 4,
+	    readonly = 5,
+	    querytimeout = 6
+    };
+
     // Options constructor sets reasonable defaults.
     Options();
     Options(const Options& options);
@@ -39,6 +49,11 @@ public:
 
     uint32_t getQueryTimeout() const;
     void setQueryTimeout(uint32_t);
+
+    void setNonDefault(Option);
+    void unsetNonDefault(Option);
+    bool isNonDefault(Option);
+
 private:
     RowMode rowMode;
     uint32_t fetchSize;
@@ -46,10 +61,12 @@ private:
     bool autoCommit;
     bool readOnly;
     uint32_t queryTimeout;
+    int defaults = 0;
 };
 
 // getJsonOptions returns the JSON query options provided by the user
 void getJsonOptions(Local<Object> object, Options& options);
+
 }
 
 #endif

--- a/test/21.pooling.js
+++ b/test/21.pooling.js
@@ -26,7 +26,8 @@ const badPoolArgs = {
   wrong: "this is not how it is done",
 };
 
-describe("14 test pooling", () => {
+describe("14 test pooling", function () {
+  this.timeout(500000);
   let pool = null;
   let connections = null;
 
@@ -74,7 +75,7 @@ describe("14 test pooling", () => {
     should.equal(
       pool.free_connections.length,
       10,
-      "pool shoul return to 10 free connections once connection is released"
+      "pool should return to 10 free connections once connection is released"
     );
   });
 

--- a/test/6.autoCommit.js
+++ b/test/6.autoCommit.js
@@ -12,6 +12,7 @@ var config = require("./config");
 var helper = require("./typeHelper");
 
 describe("6. autoCommit.js", function () {
+  this.timeout(5000);
   var driver = null;
   var connection = null;
   var tableName = "auto_commit";


### PR DESCRIPTION
changes made to fix undesired autocommit toggling and allow liveliness connection checks to avoid provoking queries when released.  This passes existing tests, including pooling tests and auto commit.  Some tests for network failures needed to be commented out since they are not working without specific setup but that is not related to these changes.  Those tests need to be handled separately, but the deadlock test was turned back on since it now passes with the auto commit changes.

There are two key principles here, auto commit was basically failing because previous changes for handling options were resetting options back to default values in particular circumstances, which was not desired.  Second, code was added for additional options to disable queries for liveliness tests when returning a connection to the connection pool.  It can now just to a quicker check by looking for errors and connections that are no longer considered connected.