### PR TITLE
Add throw to places in the pool.js where we previously ate exceptions

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -134,7 +134,7 @@ class Pool {
     try {
       await this.all_connections[_id].connection._defaultClose();
     } catch (e) {
-      // continue regardless of error
+      throw e;
     }
     clearTimeout(this.all_connections[_id].ageOutID);
     delete this.all_connections[_id];
@@ -273,7 +273,7 @@ class Pool {
       try {
         await connection._defaultClose();
       } catch (e) {
-        // continue regardless of error
+        throw e
       }
       if (this.free_connections.length < this.config.minAvailable) {
         let newConn = await this._createConnection();
@@ -300,7 +300,7 @@ class Pool {
           await this.all_connections[key].connection._defaultClose();
           clearTimeout(this.all_connections[key].ageOutID);
         } catch (e) {
-          // continue regardless of error
+          throw e;
         }
       })
     );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-nuodb",
-  "version": "3.4.1",
+  "version": "3.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-nuodb",
-      "version": "3.4.1",
+      "version": "3.5.1",
       "license": "Apache-2.0",
       "dependencies": {
         "bindings": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "NuoDB, Inc.",
   "description": "The official NuoDB driver for Node.js. Provides a high-level SQL API on top of the NuoDB Node.js Addon.",
   "license": "Apache-2.0",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "main": "index.js",
   "keywords": [
     "nuodb",


### PR DESCRIPTION
This change is to force an exceptions caught in pool.js that were previously ignored to become visible to the application.  Primarily we are looking to see if unexpected failures are occurring in the driver that are causing connections to persist in the TE after they were intended to be closed.