### PR TITLE
Close a loophole to make sure maxLimit for connections is always resp…

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -141,6 +141,7 @@ class Pool {
   }
 
   async _populationCheck() {
+    // create a connection if we are not at maximum and we do not have a minimum amount of free connections
     if (Object.keys(this.all_connections).length < this.config.maxLimit &&
        this.free_connections.length < this.config.minAvailable 
     ) {
@@ -232,25 +233,19 @@ class Pool {
     if (this.state === Pool.STATE_CLOSING || this.state === Pool.STATE_CLOSED) {
       throw new Error("the pool is closing or closed");
     }
-    if (this.config.maxLimit > 0) {
-      if (
-        Object.keys(this.all_connections).length >= this.config.maxLimit &&
-        this.free_connections.length === 0
-      ) {
-        throw new Error("connection hard limit reached");
-      }
-    }
-    // if a connection is available, use free connection
+    // if there is a free connection, use it
     if (this.free_connections.length > 0) {
       const connectionToUse = this.free_connections.shift();
       this.all_connections[connectionToUse._id].inUse = true;
       return connectionToUse;
-    }
-    // if no available connections, make one
-    else if (this.free_connections.length === 0) {
+    // if there are no free connection and we are not at maxLimit then create a connection
+    } else if (Object.keys(this.all_connections).length < this.config.maxLimit) {
       const connectionToUse = await this._createConnection();
       this.all_connections[connectionToUse._id].inUse = true;
       return connectionToUse;
+    // there is no free connection, but maxLimit has been reached
+    } else {
+      throw new Error("connection hard limit reached");
     }
   }
 
@@ -277,6 +272,7 @@ class Pool {
       } catch (e) {
         throw e
       }
+      // after aging out the released connection, backfill a replacement connection when appropriate
       if (Object.keys(this.all_connections).length < this.config.maxLimit &&
          this.free_connections.length < this.config.minAvailable 
       ) {
@@ -285,8 +281,9 @@ class Pool {
       }
       return;
     }
-    // Determine if the connection has any problem to avoid keeping and returning a bad
-    // connection to the pool
+    // If the connection has not aged out, determine if the connection has any problem
+    // close any bad connection and avoid returning a bad connection to the pool
+    // all connections that are still useable can be returned to the pool
     const connectionAlive = await this._checkConnection(connection); //returns boolean
     if (connectionAlive) {
       this.all_connections[connection._id].inUse = false;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-nuodb",
-  "version": "3.5.2",
+  "version": "3.5.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-nuodb",
-      "version": "3.5.2",
+      "version": "3.5.3",
       "license": "Apache-2.0",
       "dependencies": {
         "bindings": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "NuoDB, Inc.",
   "description": "The official NuoDB driver for Node.js. Provides a high-level SQL API on top of the NuoDB Node.js Addon.",
   "license": "Apache-2.0",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "main": "index.js",
   "keywords": [
     "nuodb",


### PR DESCRIPTION
Changed the "if" logic in requestConnection to only create a connection when we have not reached the maxLimit, this fixes a hole where it was possible to create a connection when there are no connections in the free pool, and we have already hit the max connection limit.