### PR TITLE
Closestats

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -5,6 +5,8 @@
 
 'use strict';
 
+const logger = require('./logger');
+
 var addon = require('bindings')('nuodb.node');
 
 var Connection = require('./connection')

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -12,272 +12,183 @@ var Driver = require("./driver");
 const REQUIRED_INITIAL_ARGUMENTS = ["connectionConfig"];
 
 class Pool {
-  static STATE_INITIALIZING = "initializing";
-  static STATE_RUNNING = "running";
-  static STATE_CLOSING = "closing";
-  static STATE_CLOSED = "closed";
-  static LIVELINESS_RUNNING = "liveliness running";
-  static LIVELINESS_NOT_RUNNING = "liveliness not running";
+    static STATE_INITIALIZING = "initializing";
+    static STATE_RUNNING = "running";
+    static STATE_CLOSING = "closing";
+    static STATE_CLOSED = "closed";
+    static LIVELINESS_RUNNING = "liveliness running";
+    static LIVELINESS_NOT_RUNNING = "liveliness not running";
 
 
-  constructor(args) {
-    REQUIRED_INITIAL_ARGUMENTS.forEach((arg) => {
-      if (!(arg in args)) {
-	let err = new Error(`cannot find required argument ${arg} in constructor arguments`);
-	logger.error(err);
-	throw err;
-      }
-    });
-
-    this.closeCall = 0;
-    this.closeNext = 0;
-    this.releaseCall = 0;
-    this.releaseReplaced = 0;
-    this.releaseAged = 0;
-    this.releasePushActive = 0;
-    this.releaseCloseDead = 0;
-//    this.sleep = (delay) => new Promise((resolve) => setTimeout(resolve, delay))
-
-    this.config = {
-      minAvailable: args.minAvailable || 10,
-      connectionConfig: args.connectionConfig,
-      maxAge: args.maxAge || 300000,
-      checkTime: args.checkTime ?? 120000, // how often to run the livliness check, will not run when set to 0
-      maxLimit: args.maxLimit ?? 200,
-      connectionRetryLimit: args.connectionRetryLimit || 5,
-      skipCheckLivelinessOnRelease : args.skipCheckLivelinessOnRelease ?? false,
-      livelinessCheck: args.livelinessCheck ?? 'query'
-    };
-    this.poolId = args.id || new Date().getTime();
-
-    this.all_connections = {};
-
-    this.free_connections = [];
-
-    this.state = Pool.STATE_INITIALIZING;
-
-    this.livelinessStatus = Pool.LIVELINESS_NOT_RUNNING;
-
-    //start liveliness check
-    if (this.config.checkTime != 0) {
-      this.livelinessInterval = setInterval(
-        () => this._livelinessCheck(),
-        this.config.checkTime
-      );
-    }
-  }
-  // populate the pool and prepare for use
-  async init() {
-    for (let i = 0; i < this.config.minAvailable; i++) {
-      const newConn = await this._createConnection();
-      this.free_connections.push(newConn);
-    }
-    this.state = Pool.STATE_RUNNING;
-  }
-  //verify that connection belongs in this pool
-  _connectionBelongs(connection) {
-    if (this.all_connections[connection._id] === undefined) {
-      return false;
-    }
-    if (this.all_connections[connection._id].connection === undefined) {
-      return false;
-    }
-    return connection === this.all_connections[connection._id].connection;
-  }
-  // check connection is alive
-  // First check if a liveliness check is desired and if so
-  // check at least the connection believed to be connenected
-  // and if indicated to full check by running a query
-  // if any of the desired checks show a problem return false,
-  // indicating the connection is a problem, otherwise return true
-  async _checkConnection(connection) {
-    let retvalue = true;
-    if (this.config.skipCheckLivelinessOnRelease === false) {
-      if (connection.hasFailed() === false) {
-        if (this.config.livelinessCheck.toLowerCase() === 'query') {
-          try {
-            const result = await connection.execute("SELECT 1 AS VALUE FROM DUAL");
-            await result.close();
-          } catch (err) {
-	    logger.error(err);
-            retvalue = false;
-          }
-        }
-      } else {
-        retvalue = false;
-      }
-    }
-    // if we get here it means either we want all connections put back in the pool or any of liveliness check
-    // performed, either a connection check or a full query all passed
-    return retvalue;
-  }
-  //connection will be checked when releaseConnection is called on it.
-  async _livelinessCheck() {
-    if (this.livelinessStatus === Pool.LIVELINESS_RUNNING) {
-      return;
-    }
-    if (this.free_connections.length === 0) {
-      return;
-    }
-    this.livelinessStatus = Pool.LIVELINESS_RUNNING;
-    const checked = {};
-    while (this.free_connections.length > 0) {
-      let toCheck = this.free_connections.shift();
-      this.all_connections[toCheck._id].inUse = true;
-      if (checked[toCheck._id] === true) {
-        await this.releaseConnection(toCheck);
-        return;
-      }
-      checked[toCheck._id] = true;
-      await this.releaseConnection(toCheck);
-    }
-    this.livelinessStatus = Pool.LIVELINESS_NOT_RUNNING;
-  }
-
-  _checkFreeAndRemove(_id) {
-    for (let i = 0; i < this.free_connections.length; i++) {
-      if (this.free_connections[i]._id === _id) {
-        this.free_connections.splice(i, 1);
-        return true;
-      }
-    }
-    return false;
-  }
-
-  async _checkAllAndRemove(_id) {
-    try {
-      await clearTimeout(this.all_connections[_id].ageOutID);
-      await this.all_connections[_id].connection._defaultClose();
-      delete this.all_connections[_id];
-    } catch (err) {
-      logger.error(err,`id: ${_id} connection: ${this.all_connections[_id].connection}`);
-      throw err;
-    }
-  }
-
-  async _populationCheck() {
-    // create a connection if we are not at maximum and we do not have a minimum amount of free connections
-    if (Object.keys(this.all_connections).length < this.config.maxLimit &&
-       this.free_connections.length < this.config.minAvailable 
-    ) {
-      let newConn = await this._createConnection();
-      this.free_connections.push(newConn);
-    } 
-  }
-
-
-  async _closeConnection(_id) {
-    if (this.state === Pool.STATE_CLOSING || this.state === Pool.STATE_CLOSED) {
-      return;
-    }
-    //if connection is inUse mark it for closure upon return to free_connections
-    if (this.all_connections[_id].inUse) {
-      this.all_connections[_id].ageStatus = true;
-      return;
-    }
-
-    this._checkFreeAndRemove(_id);
-
-    await this._checkAllAndRemove(_id);
-
-    await this._populationCheck();
-
-  }
-
-  async _makeConnection() {
-    if ((Object.keys(this.all_connections).length > this.config.maxLimit) || (this.closeCall != this.closeNext)) {
-      logger.level = 'info';
-    } 
-    logger.info(`\ 
-                 closeCall: ${this.closeCall} \
-                 closeNext: ${this.closeNext} \
-                 requestConnection: pool: ${this.poolId} \
-                 free.length: ${this.free_connections.length} \
-                 all_connections.length: ${Object.keys(this.all_connections).length} \
-                 releaseCall: ${this.releaseCall} \
-                 releaseAged: ${this.releaseAged} \
-                 releaseReplaced: ${this.releaseReplaced} \
-                 releasePushActive: ${this.releasePushActive} \
-                 releaseCloseDead: ${this.releaseCloseDead} \
-      `);
-    const driver = new Driver();
-    let connection = await driver.connect(this.config.connectionConfig);
-    const results = await connection.execute(
-      "SELECT GETCONNECTIONID() FROM DUAL"
-    );
-    const connId = await results.getRows();
-    connection.id = connId[0]["[GETCONNECTIONID]"];
-    const thisPool = this;
-    // Every connection object has a default close function that calls the 
-    // The underlying actual NuoDB Conneciton close function.
-    // This replaces the connection function pointer to go through a wrapper
-    // that is used to gather any stats about closing, then it invokes the
-    // the original close function that was associated with the conneciton instance
-    // The orginal function is stored in case the conneciton prototype that 
-    // that establishes the original call is ever modified.
-//    connection._defaultClose = connection.close;
-    connection._defaultOrigClose = connection.close;
-    connection._defaultClose = async () => {
-	    this.closeCall += 1;
-	    try {
-	      await connection._defaultOrigClose();
-	    } catch (err) {
-	      logger.error(err);
-	      if (err != 'Error: failed to close connection [connection closed]') {
+    constructor(args) {
+        REQUIRED_INITIAL_ARGUMENTS.forEach((arg) => {
+            if (!(arg in args)) {
+                let err = new Error(`cannot find required argument ${arg} in constructor arguments`);
+                logger.error(err);
                 throw err;
-	      }
-	    }
-	    this.closeNext += 1;
-    }
-    connection.close = async () => {
-      await thisPool.releaseConnection(connection);
-    };
-    let _id = 0;
-    while (this.all_connections[_id] != undefined) {
-      _id++;
-    }
-    connection._id = _id;
-    this.all_connections[_id] = {
-      connection: connection,
-      ageStatus: false,
-      ageOutID: null,
-      inUse: false,
-    };
+            }
+        });
 
-    this.all_connections[_id].ageOutID = setTimeout(
-      () => this._closeConnection(_id),
-      this.config.maxAge,
-      _id
-    );
-    return connection;
-  }
+        this.closeCall = 0;
+        this.closeNext = 0;
+        this.releaseCall = 0;
+        this.releaseReplaced = 0;
+        this.releaseAged = 0;
+        this.releasePushActive = 0;
+        this.releaseCloseDead = 0;
+        //    this.sleep = (delay) => new Promise((resolve) => setTimeout(resolve, delay))
 
-  async _createConnection() {
-    let error;
-    let connectionMade;
-    let tries = 0;
-    const maxTries = this.config.connectionRetryLimit;
-    while (tries < maxTries && connectionMade === undefined) {
-      try {
-        connectionMade = await this._makeConnection();
-      } catch (err) {
-        tries++;
-        error = err;
-      }
-    }
-    if (tries >= maxTries) {
-      logger.error(error,'createConnection');
-      throw error;
-    }
-    return connectionMade;
-  }
+        this.config = {
+            minAvailable: args.minAvailable || 10,
+            connectionConfig: args.connectionConfig,
+            maxAge: args.maxAge || 300000,
+            checkTime: args.checkTime ?? 120000, // how often to run the livliness check, will not run when set to 0
+            maxLimit: args.maxLimit ?? 200,
+            connectionRetryLimit: args.connectionRetryLimit || 5,
+            skipCheckLivelinessOnRelease: args.skipCheckLivelinessOnRelease ?? false,
+            livelinessCheck: args.livelinessCheck ?? 'query'
+        };
+        this.poolId = args.id || new Date().getTime();
 
-  async requestConnection() {
-    this.callRequest =+ 1;
-    if ((Object.keys(this.all_connections).length > this.config.maxLimit) || (this.closeCall != this.closeNext)) {
-      logger.level = 'info';
-    } 
-    logger.info(`\ 
+        this.all_connections = {};
+
+        this.free_connections = [];
+
+        this.state = Pool.STATE_INITIALIZING;
+
+        this.livelinessStatus = Pool.LIVELINESS_NOT_RUNNING;
+
+        //start liveliness check
+        if (this.config.checkTime != 0) {
+            this.livelinessInterval = setInterval(
+                () => this._livelinessCheck(),
+                this.config.checkTime
+            );
+        }
+    }
+    // populate the pool and prepare for use
+    async init() {
+        for (let i = 0; i < this.config.minAvailable; i++) {
+            const newConn = await this._createConnection();
+            this.free_connections.push(newConn);
+        }
+        this.state = Pool.STATE_RUNNING;
+    }
+    //verify that connection belongs in this pool
+    _connectionBelongs(connection) {
+        if (this.all_connections[connection._id] === undefined) {
+            return false;
+        }
+        if (this.all_connections[connection._id].connection === undefined) {
+            return false;
+        }
+        return connection === this.all_connections[connection._id].connection;
+    }
+    // check connection is alive
+    // First check if a liveliness check is desired and if so
+    // check at least the connection believed to be connenected
+    // and if indicated to full check by running a query
+    // if any of the desired checks show a problem return false,
+    // indicating the connection is a problem, otherwise return true
+    async _checkConnection(connection) {
+        let retvalue = true;
+        if (this.config.skipCheckLivelinessOnRelease === false) {
+            if (connection.hasFailed() === false) {
+                if (this.config.livelinessCheck.toLowerCase() === 'query') {
+                    try {
+                        const result = await connection.execute("SELECT 1 AS VALUE FROM DUAL");
+                        await result.close();
+                    } catch (err) {
+                        logger.error(err);
+                        retvalue = false;
+                    }
+                }
+            } else {
+                retvalue = false;
+            }
+        }
+        // if we get here it means either we want all connections put back in the pool or any of liveliness check
+        // performed, either a connection check or a full query all passed
+        return retvalue;
+    }
+    //connection will be checked when releaseConnection is called on it.
+    async _livelinessCheck() {
+        if (this.livelinessStatus === Pool.LIVELINESS_RUNNING) {
+            return;
+        }
+        if (this.free_connections.length === 0) {
+            return;
+        }
+        this.livelinessStatus = Pool.LIVELINESS_RUNNING;
+        const checked = {};
+        while (this.free_connections.length > 0) {
+            let toCheck = this.free_connections.shift();
+            this.all_connections[toCheck._id].inUse = true;
+            if (checked[toCheck._id] === true) {
+                await this.releaseConnection(toCheck);
+                return;
+            }
+            checked[toCheck._id] = true;
+            await this.releaseConnection(toCheck);
+        }
+        this.livelinessStatus = Pool.LIVELINESS_NOT_RUNNING;
+    }
+
+    _checkFreeAndRemove(_id) {
+        for (let i = 0; i < this.free_connections.length; i++) {
+            if (this.free_connections[i]._id === _id) {
+                this.free_connections.splice(i, 1);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    async _checkAllAndRemove(_id) {
+        try {
+            await clearTimeout(this.all_connections[_id].ageOutID);
+            await this.all_connections[_id].connection._defaultClose();
+            delete this.all_connections[_id];
+        } catch (err) {
+            logger.error(err, `id: ${_id} connection: ${this.all_connections[_id].connection}`);
+            throw err;
+        }
+    }
+
+    async _populationCheck() {
+        // create a connection if we are not at maximum and we do not have a minimum amount of free connections
+        if (Object.keys(this.all_connections).length < this.config.maxLimit &&
+            this.free_connections.length < this.config.minAvailable
+        ) {
+            let newConn = await this._createConnection();
+            this.free_connections.push(newConn);
+        }
+    }
+
+
+    async _closeConnection(_id) {
+        if (this.state === Pool.STATE_CLOSING || this.state === Pool.STATE_CLOSED) {
+            return;
+        }
+        //if connection is inUse mark it for closure upon return to free_connections
+        if (this.all_connections[_id].inUse) {
+            this.all_connections[_id].ageStatus = true;
+            return;
+        }
+
+        this._checkFreeAndRemove(_id);
+
+        await this._checkAllAndRemove(_id);
+
+        await this._populationCheck();
+
+    }
+
+    async _makeConnection() {
+        if ((Object.keys(this.all_connections).length > this.config.maxLimit) || (this.closeCall != this.closeNext)) {
+            logger.level = 'info';
+        }
+        logger.info(`\ 
                  closeCall: ${this.closeCall} \
                  closeNext: ${this.closeNext} \
                  requestConnection: pool: ${this.poolId} \
@@ -289,113 +200,202 @@ class Pool {
                  releasePushActive: ${this.releasePushActive} \
                  releaseCloseDead: ${this.releaseCloseDead} \
       `);
-    if (this.state === Pool.STATE_INITIALIZING) {
-      let err =new Error("must initialize the pool before requesting a connection");
-      logger.error(err);
-      throw err;
-    }
-    if (this.state === Pool.STATE_CLOSING || this.state === Pool.STATE_CLOSED) {
-      let err = new Error("the pool is closing or closed");
-      logger.error(err);
-      throw err;
-    }
-    // if there is a free connection, use it
-    if (this.free_connections.length > 0) {
-      this.freeRequest =+ 1;
-      const connectionToUse = this.free_connections.shift();
-      this.all_connections[connectionToUse._id].inUse = true;
-      return connectionToUse;
-    // if there are no free connection and we are not at maxLimit then create a connection
-    } else if (Object.keys(this.all_connections).length < this.config.maxLimit) {
-      this.createRequest =+ 1;
-      const connectionToUse = await this._createConnection();
-      this.all_connections[connectionToUse._id].inUse = true;
-      return connectionToUse;
-    // there is no free connection, but maxLimit has been reached
-    } else {
-      let err = new Error("connection hard limit reached");
-      logger.error(err);
-      throw err;
-    }
-  }
-
-  async releaseConnection(connection) {
-    this.releaseCall += 1;
-    let cid = connection.id;
-    if (this.state !== Pool.STATE_RUNNING) {
-      let err = new Error(`cannot release connections to a pool that is not running, current state: ${this.state}`);
-      logger.error(err,`connection: ${connection}`);
-      throw err;
-    }
-    if (!this._connectionBelongs(connection)) {
-      let err = new Error('connection is not from this pool');
-      logger.error(err);
-      throw err;
-    }
-    if (this.all_connections[connection._id].inUse === false) {
-      let err = new Error("cannot return a connection that has already been returned to the pool");
-      logger.error(err,`connection: ${connection}`);
-      throw err;
-    }
-    // if aged out connection is returned to the pool, close it
-    if (this.all_connections[connection._id].ageStatus === true) {
-      this.releaseAged += 1;
-      try {
-        await clearTimeout(this.all_connections[connection._id].ageOutID);
-        await connection._defaultClose();
-        delete this.all_connections[connection._id];
-      } catch (err) {
-        logger.error(err,'connection: ${connection} Closing Aged Connection upon Pool return');
-        throw err;
-      }
-      // after aging out the released connection, backfill a replacement connection when appropriate
-      if (Object.keys(this.all_connections).length < this.config.maxLimit &&
-         this.free_connections.length < this.config.minAvailable 
-      ) {
-	this.releaseReplaced += 1;
-        let newConn = await this._createConnection();
-        this.free_connections.push(newConn);
-      }
-
-      return;
-    }
-    // If the connection has not aged out, determine if the connection has any problem
-    // close any bad connection and avoid returning a bad connection to the pool
-    // all connections that are still useable can be returned to the pool
-    const connectionAlive = await this._checkConnection(connection); //returns boolean
-    if (connectionAlive) {
-      this.releasePushAlive += 1;
-      this.all_connections[connection._id].inUse = false;
-      this.free_connections.push(connection);
-    } else {
-      this.releaseCloseDead += 1; 
-      await this._closeConnection(connection._id);
-    }
-  }
-
-  async closePool() {
-    this.state = Pool.STATE_CLOSING;
-    await Promise.all(
-      Object.keys(this.all_connections).map(async (key) => {
-        try {
-          await clearTimeout(this.all_connections[key].ageOutID);
-          await this.all_connections[key].connection._defaultClose();
-          delete this.all_connections[key];
-        } catch (err) {
-          logger.error(err,'Close Pool');
-	  if (err != 'Error: failed to close connection [connection closed]') {
-            throw err;
-	  }
+        const driver = new Driver();
+        let connection = await driver.connect(this.config.connectionConfig);
+        const results = await connection.execute(
+            "SELECT GETCONNECTIONID() FROM DUAL"
+        );
+        const connId = await results.getRows();
+        connection.id = connId[0]["[GETCONNECTIONID]"];
+        const thisPool = this;
+        // Every connection object has a default close function that calls the 
+        // The underlying actual NuoDB Conneciton close function.
+        // This replaces the connection function pointer to go through a wrapper
+        // that is used to gather any stats about closing, then it invokes the
+        // the original close function that was associated with the conneciton instance
+        // The orginal function is stored in case the conneciton prototype that 
+        // that establishes the original call is ever modified.
+        //    connection._defaultClose = connection.close;
+        connection._defaultOrigClose = connection.close;
+        connection._defaultClose = async () => {
+            this.closeCall += 1;
+            try {
+                await connection._defaultOrigClose();
+            } catch (err) {
+                logger.error(err);
+                if (err != 'Error: failed to close connection [connection closed]') {
+                    throw err;
+                }
+            }
+            this.closeNext += 1;
         }
-      })
-    );
-    this.all_connections = {};
-    this.free_connections = [];
-    if (this.config.checkTime != 0) {
-      clearInterval(this.livelinessInterval);
+        connection.close = async () => {
+            await thisPool.releaseConnection(connection);
+        };
+        let _id = 0;
+        while (this.all_connections[_id] != undefined) {
+            _id++;
+        }
+        connection._id = _id;
+        this.all_connections[_id] = {
+            connection: connection,
+            ageStatus: false,
+            ageOutID: null,
+            inUse: false,
+        };
+
+        this.all_connections[_id].ageOutID = setTimeout(
+            () => this._closeConnection(_id),
+            this.config.maxAge,
+            _id
+        );
+        return connection;
     }
-    this.state = Pool.STATE_CLOSED;
-  }
+
+    async _createConnection() {
+        let error;
+        let connectionMade;
+        let tries = 0;
+        const maxTries = this.config.connectionRetryLimit;
+        while (tries < maxTries && connectionMade === undefined) {
+            try {
+                connectionMade = await this._makeConnection();
+            } catch (err) {
+                tries++;
+                error = err;
+            }
+        }
+        if (tries >= maxTries) {
+            logger.error(error, 'createConnection');
+            throw error;
+        }
+        return connectionMade;
+    }
+
+    async requestConnection() {
+        this.callRequest = +1;
+        if ((Object.keys(this.all_connections).length > this.config.maxLimit) || (this.closeCall != this.closeNext)) {
+            logger.level = 'info';
+        }
+        logger.info(`\ 
+                 closeCall: ${this.closeCall} \
+                 closeNext: ${this.closeNext} \
+                 requestConnection: pool: ${this.poolId} \
+                 free.length: ${this.free_connections.length} \
+                 all_connections.length: ${Object.keys(this.all_connections).length} \
+                 releaseCall: ${this.releaseCall} \
+                 releaseAged: ${this.releaseAged} \
+                 releaseReplaced: ${this.releaseReplaced} \
+                 releasePushActive: ${this.releasePushActive} \
+                 releaseCloseDead: ${this.releaseCloseDead} \
+      `);
+        if (this.state === Pool.STATE_INITIALIZING) {
+            let err = new Error("must initialize the pool before requesting a connection");
+            logger.error(err);
+            throw err;
+        }
+        if (this.state === Pool.STATE_CLOSING || this.state === Pool.STATE_CLOSED) {
+            let err = new Error("the pool is closing or closed");
+            logger.error(err);
+            throw err;
+        }
+        // if there is a free connection, use it
+        if (this.free_connections.length > 0) {
+            this.freeRequest = +1;
+            const connectionToUse = this.free_connections.shift();
+            this.all_connections[connectionToUse._id].inUse = true;
+            return connectionToUse;
+            // if there are no free connection and we are not at maxLimit then create a connection
+        } else if (Object.keys(this.all_connections).length < this.config.maxLimit) {
+            this.createRequest = +1;
+            const connectionToUse = await this._createConnection();
+            this.all_connections[connectionToUse._id].inUse = true;
+            return connectionToUse;
+            // there is no free connection, but maxLimit has been reached
+        } else {
+            let err = new Error("connection hard limit reached");
+            logger.error(err);
+            throw err;
+        }
+    }
+
+    async releaseConnection(connection) {
+        this.releaseCall += 1;
+        let cid = connection.id;
+        if (this.state !== Pool.STATE_RUNNING) {
+            let err = new Error(`cannot release connections to a pool that is not running, current state: ${this.state}`);
+            logger.error(err, `connection: ${connection}`);
+            throw err;
+        }
+        if (!this._connectionBelongs(connection)) {
+            let err = new Error('connection is not from this pool');
+            logger.error(err);
+            throw err;
+        }
+        if (this.all_connections[connection._id].inUse === false) {
+            let err = new Error("cannot return a connection that has already been returned to the pool");
+            logger.error(err, `connection: ${connection}`);
+            throw err;
+        }
+        // if aged out connection is returned to the pool, close it
+        if (this.all_connections[connection._id].ageStatus === true) {
+            this.releaseAged += 1;
+            try {
+                await clearTimeout(this.all_connections[connection._id].ageOutID);
+                await connection._defaultClose();
+                delete this.all_connections[connection._id];
+            } catch (err) {
+                logger.error(err, 'connection: ${connection} Closing Aged Connection upon Pool return');
+                throw err;
+            }
+            // after aging out the released connection, backfill a replacement connection when appropriate
+            if (Object.keys(this.all_connections).length < this.config.maxLimit &&
+                this.free_connections.length < this.config.minAvailable
+            ) {
+                this.releaseReplaced += 1;
+                let newConn = await this._createConnection();
+                this.free_connections.push(newConn);
+            }
+
+            return;
+        }
+        // If the connection has not aged out, determine if the connection has any problem
+        // close any bad connection and avoid returning a bad connection to the pool
+        // all connections that are still useable can be returned to the pool
+        const connectionAlive = await this._checkConnection(connection); //returns boolean
+        if (connectionAlive) {
+            this.releasePushAlive += 1;
+            this.all_connections[connection._id].inUse = false;
+            this.free_connections.push(connection);
+        } else {
+            this.releaseCloseDead += 1;
+            await this._closeConnection(connection._id);
+        }
+    }
+
+    async closePool() {
+        this.state = Pool.STATE_CLOSING;
+        await Promise.all(
+            Object.keys(this.all_connections).map(async (key) => {
+                try {
+                    await clearTimeout(this.all_connections[key].ageOutID);
+                    await this.all_connections[key].connection._defaultClose();
+                    delete this.all_connections[key];
+                } catch (err) {
+                    logger.error(err, 'Close Pool');
+                    if (err != 'Error: failed to close connection [connection closed]') {
+                        throw err;
+                    }
+                }
+            })
+        );
+        this.all_connections = {};
+        this.free_connections = [];
+        if (this.config.checkTime != 0) {
+            clearInterval(this.livelinessInterval);
+        }
+        this.state = Pool.STATE_CLOSED;
+    }
 }
 
 module.exports = Pool;

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -19,6 +19,7 @@ class Pool {
   static LIVELINESS_RUNNING = "liveliness running";
   static LIVELINESS_NOT_RUNNING = "liveliness not running";
 
+
   constructor(args) {
     REQUIRED_INITIAL_ARGUMENTS.forEach((arg) => {
       if (!(arg in args)) {
@@ -27,6 +28,16 @@ class Pool {
 	throw err;
       }
     });
+
+    this.closeCall = 0;
+    this.closeNext = 0;
+    this.releaseCall = 0;
+    this.releaseReplaced = 0;
+    this.releaseAged = 0;
+    this.releasePushActive = 0;
+    this.releaseCloseDead = 0;
+//    this.sleep = (delay) => new Promise((resolve) => setTimeout(resolve, delay))
+
     this.config = {
       minAvailable: args.minAvailable || 10,
       connectionConfig: args.connectionConfig,
@@ -58,7 +69,6 @@ class Pool {
   // populate the pool and prepare for use
   async init() {
     for (let i = 0; i < this.config.minAvailable; i++) {
-      logger.trace(`Pool Init: createConnection`);
       const newConn = await this._createConnection();
       this.free_connections.push(newConn);
     }
@@ -136,13 +146,13 @@ class Pool {
 
   async _checkAllAndRemove(_id) {
     try {
+      await clearTimeout(this.all_connections[_id].ageOutID);
       await this.all_connections[_id].connection._defaultClose();
+      delete this.all_connections[_id];
     } catch (err) {
-      logger.error(err,`id: ${id} connection: ${this.all_connections[_id].connection}`);
+      logger.error(err,`id: ${_id} connection: ${this.all_connections[_id].connection}`);
       throw err;
     }
-    clearTimeout(this.all_connections[_id].ageOutID);
-    delete this.all_connections[_id];
   }
 
   async _populationCheck() {
@@ -150,14 +160,11 @@ class Pool {
     if (Object.keys(this.all_connections).length < this.config.maxLimit &&
        this.free_connections.length < this.config.minAvailable 
     ) {
-      logger.trace(`populationCheck: createConnection`);
       let newConn = await this._createConnection();
       this.free_connections.push(newConn);
-      return;
-    } else {
-      return;
-    }
+    } 
   }
+
 
   async _closeConnection(_id) {
     if (this.state === Pool.STATE_CLOSING || this.state === Pool.STATE_CLOSED) {
@@ -175,10 +182,24 @@ class Pool {
 
     await this._populationCheck();
 
-    return;
   }
 
   async _makeConnection() {
+    if ((Object.keys(this.all_connections).length > this.config.maxLimit) || (this.closeCall != this.closeNext)) {
+      logger.level = 'info';
+    } 
+    logger.info(`\ 
+                 closeCall: ${this.closeCall} \
+                 closeNext: ${this.closeNext} \
+                 requestConnection: pool: ${this.poolId} \
+                 free.length: ${this.free_connections.length} \
+                 all_connections.length: ${Object.keys(this.all_connections).length} \
+                 releaseCall: ${this.releaseCall} \
+                 releaseAged: ${this.releaseAged} \
+                 releaseReplaced: ${this.releaseReplaced} \
+                 releasePushActive: ${this.releasePushActive} \
+                 releaseCloseDead: ${this.releaseCloseDead} \
+      `);
     const driver = new Driver();
     let connection = await driver.connect(this.config.connectionConfig);
     const results = await connection.execute(
@@ -187,7 +208,27 @@ class Pool {
     const connId = await results.getRows();
     connection.id = connId[0]["[GETCONNECTIONID]"];
     const thisPool = this;
-    connection._defaultClose = connection.close;
+    // Every connection object has a default close function that calls the 
+    // The underlying actual NuoDB Conneciton close function.
+    // This replaces the connection function pointer to go through a wrapper
+    // that is used to gather any stats about closing, then it invokes the
+    // the original close function that was associated with the conneciton instance
+    // The orginal function is stored in case the conneciton prototype that 
+    // that establishes the original call is ever modified.
+//    connection._defaultClose = connection.close;
+    connection._defaultOrigClose = connection.close;
+    connection._defaultClose = async () => {
+	    this.closeCall += 1;
+	    try {
+	      await connection._defaultOrigClose();
+	    } catch (err) {
+	      logger.error(err);
+	      if (err != 'Error: failed to close connection [connection closed]') {
+                throw err;
+	      }
+	    }
+	    this.closeNext += 1;
+    }
     connection.close = async () => {
       await thisPool.releaseConnection(connection);
     };
@@ -228,11 +269,26 @@ class Pool {
       logger.error(error,'createConnection');
       throw error;
     }
-    logger.trace(connectionMade, `createConnection`);
     return connectionMade;
   }
 
   async requestConnection() {
+    this.callRequest =+ 1;
+    if ((Object.keys(this.all_connections).length > this.config.maxLimit) || (this.closeCall != this.closeNext)) {
+      logger.level = 'info';
+    } 
+    logger.info(`\ 
+                 closeCall: ${this.closeCall} \
+                 closeNext: ${this.closeNext} \
+                 requestConnection: pool: ${this.poolId} \
+                 free.length: ${this.free_connections.length} \
+                 all_connections.length: ${Object.keys(this.all_connections).length} \
+                 releaseCall: ${this.releaseCall} \
+                 releaseAged: ${this.releaseAged} \
+                 releaseReplaced: ${this.releaseReplaced} \
+                 releasePushActive: ${this.releasePushActive} \
+                 releaseCloseDead: ${this.releaseCloseDead} \
+      `);
     if (this.state === Pool.STATE_INITIALIZING) {
       let err =new Error("must initialize the pool before requesting a connection");
       logger.error(err);
@@ -243,15 +299,15 @@ class Pool {
       logger.error(err);
       throw err;
     }
-    logger.info(`requestConnection: pool: ${this.poolId} free.length: ${this.free_connections.length} all_connections.length: ${Object.keys(this.all_connections).length}`);
     // if there is a free connection, use it
     if (this.free_connections.length > 0) {
+      this.freeRequest =+ 1;
       const connectionToUse = this.free_connections.shift();
       this.all_connections[connectionToUse._id].inUse = true;
       return connectionToUse;
     // if there are no free connection and we are not at maxLimit then create a connection
     } else if (Object.keys(this.all_connections).length < this.config.maxLimit) {
-      logger.trace(`requestConnection: createConnection`);
+      this.createRequest =+ 1;
       const connectionToUse = await this._createConnection();
       this.all_connections[connectionToUse._id].inUse = true;
       return connectionToUse;
@@ -264,7 +320,7 @@ class Pool {
   }
 
   async releaseConnection(connection) {
-    logger.trace(connection,`Enter releaseConnection`);
+    this.releaseCall += 1;
     let cid = connection.id;
     if (this.state !== Pool.STATE_RUNNING) {
       let err = new Error(`cannot release connections to a pool that is not running, current state: ${this.state}`);
@@ -283,10 +339,11 @@ class Pool {
     }
     // if aged out connection is returned to the pool, close it
     if (this.all_connections[connection._id].ageStatus === true) {
-      clearTimeout(this.all_connections[connection._id].ageOutID);
-      delete this.all_connections[connection._id];
+      this.releaseAged += 1;
       try {
+        await clearTimeout(this.all_connections[connection._id].ageOutID);
         await connection._defaultClose();
+        delete this.all_connections[connection._id];
       } catch (err) {
         logger.error(err,'connection: ${connection} Closing Aged Connection upon Pool return');
         throw err;
@@ -295,14 +352,11 @@ class Pool {
       if (Object.keys(this.all_connections).length < this.config.maxLimit &&
          this.free_connections.length < this.config.minAvailable 
       ) {
-	logger.trace(`releaseConnection: ${connection} createConnection`);
+	this.releaseReplaced += 1;
         let newConn = await this._createConnection();
         this.free_connections.push(newConn);
-      } else {
-	logger.trace(`releaseConnection: ${connection} all_connection.length: ${Object.keys(this.all_connections).length} free_connections.length: ${this.free_connections.length}`);
       }
 
-      logger.trace(`Exit releaseConnection ${cid}`);
       return;
     }
     // If the connection has not aged out, determine if the connection has any problem
@@ -310,9 +364,11 @@ class Pool {
     // all connections that are still useable can be returned to the pool
     const connectionAlive = await this._checkConnection(connection); //returns boolean
     if (connectionAlive) {
+      this.releasePushAlive += 1;
       this.all_connections[connection._id].inUse = false;
       this.free_connections.push(connection);
     } else {
+      this.releaseCloseDead += 1; 
       await this._closeConnection(connection._id);
     }
   }
@@ -322,11 +378,14 @@ class Pool {
     await Promise.all(
       Object.keys(this.all_connections).map(async (key) => {
         try {
+          await clearTimeout(this.all_connections[key].ageOutID);
           await this.all_connections[key].connection._defaultClose();
-          clearTimeout(this.all_connections[key].ageOutID);
+          delete this.all_connections[key];
         } catch (err) {
           logger.error(err,'Close Pool');
-          throw err;
+	  if (err != 'Error: failed to close connection [connection closed]') {
+            throw err;
+	  }
         }
       })
     );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-nuodb",
-  "version": "3.5.5",
+  "version": "3.5.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-nuodb",
-      "version": "3.5.5",
+      "version": "3.5.6",
       "license": "Apache-2.0",
       "dependencies": {
         "bindings": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "NuoDB, Inc.",
   "description": "The official NuoDB driver for Node.js. Provides a high-level SQL API on top of the NuoDB Node.js Addon.",
   "license": "Apache-2.0",
-  "version": "3.5.5",
+  "version": "3.5.6",
   "main": "index.js",
   "keywords": [
     "nuodb",


### PR DESCRIPTION
Added some additional statistics to see if we can understand connection leaks when used with a large amount of concurrent sessions.  Some additional "await" calls were added around close related functions since it was observed to get "connection closed" exceptions when normal close operations were occurring at the same time they were aging out.

I don't expect this will be the final form or stats or messages, but a step to see if we can observe anything during a live PCS test.

A formmater was also run on the pool.js which will show many lines might be different than the previous version.