### PR TITLE
Second set of pool stats/trace

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -7,7 +7,7 @@
 
 const logger = require("./logger");
 
-var Driver = require("./driver");
+let  Driver = require("./driver");
 
 const REQUIRED_INITIAL_ARGUMENTS = ["connectionConfig"];
 
@@ -30,13 +30,30 @@ class Pool {
       }
     });
 
-    this.closeCall = 0;
-    this.closeNext = 0;
-    this.releaseCall = 0;
-    this.releaseReplaced = 0;
-    this.releaseAged = 0;
-    this.releasePushActive = 0;
-    this.releaseCloseDead = 0;
+    this.counters = {
+      makeCall : 0,
+      makeExit : 0,
+      createCall : 0,
+      createExit: 0,
+      defaultCall : 0,
+      defaultExit : 0,
+      closeCall : 0,
+      closeExit : 0,
+      releaseCall : 0,
+      releaseExit : 0,
+      releaseReplaced : 0,
+      releaseAged : 0,
+      releasePushActive : 0,
+      releaseCloseDead : 0,
+      requestCall : 0,
+      requestExit : 0,
+      liveCall : 0,
+      liveExit : 0,
+      checkCall : 0,
+      checkExit : 0,
+      setTimeout : 0,
+    };
+
     //    this.sleep = (delay) => new Promise((resolve) => setTimeout(resolve, delay))
 
     this.config = {
@@ -73,6 +90,7 @@ class Pool {
       const newConn = await this._createConnection();
       this.free_connections.push(newConn);
     }
+    logger.warn(`init: pool: {this.poolId} ${JSON.stringify(this.config)}`);
     this.state = Pool.STATE_RUNNING;
   }
   //verify that connection belongs in this pool
@@ -92,6 +110,7 @@ class Pool {
   // if any of the desired checks show a problem return false,
   // indicating the connection is a problem, otherwise return true
   async _checkConnection(connection) {
+    this.counters.checkCall += 1;
     let retvalue = true;
     if (this.config.skipCheckLivelinessOnRelease === false) {
       if (connection.hasFailed() === false) {
@@ -112,10 +131,12 @@ class Pool {
     }
     // if we get here it means either we want all connections put back in the pool or any of liveliness check
     // performed, either a connection check or a full query all passed
+    this.counters.checkExit += 1;
     return retvalue;
   }
   //connection will be checked when releaseConnection is called on it.
   async _livelinessCheck() {
+    this.counters.liveCall += 1;
     if (this.livelinessStatus === Pool.LIVELINESS_RUNNING) {
       return;
     }
@@ -135,17 +156,20 @@ class Pool {
       }
     }
     this.livelinessStatus = Pool.LIVELINESS_NOT_RUNNING;
+    this.counters.liveExit += 1;
     return;
   }
 
   _checkFreeAndRemove(_id) {
+    let removed = false;
     for (let i = 0; i < this.free_connections.length; i++) {
       if (this.free_connections[i]._id === _id) {
         this.free_connections.splice(i, 1);
-        return true;
+        removed = true;
+	break;
       }
     }
-    return false;
+    return removed;
   }
 
   async _checkAllAndRemove(_id) {
@@ -174,11 +198,13 @@ class Pool {
   }
 
   async _closeConnection(_id) {
+    this.counters.closeCall += 1;
     if (this.state === Pool.STATE_CLOSING || this.state === Pool.STATE_CLOSED) {
       return;
     }
     //if connection is inUse mark it for closure upon return to free_connections
     if (this.all_connections[_id].inUse) {
+      logger.info(`Closing ${_id} In Use`);
       this.all_connections[_id].ageStatus = true;
       return;
     }
@@ -188,29 +214,18 @@ class Pool {
     await this._checkAllAndRemove(_id);
 
     await this._populationCheck();
+    this.counters.closeExit += 1;
   }
 
   async _makeConnection() {
+    this.counters.makeCall += 1;
     if (
       Object.keys(this.all_connections).length > this.config.maxLimit ||
-      this.closeCall != this.closeNext
+      this.counters.closeCall != this.counters.closeExit
     ) {
       logger.level = "info";
     }
-    logger.info(`\ 
-                 closeCall: ${this.closeCall} \
-                 closeNext: ${this.closeNext} \
-                 requestConnection: pool: ${this.poolId} \
-                 free.length: ${this.free_connections.length} \
-                 all_connections.length: ${
-                   Object.keys(this.all_connections).length
-                 } \
-                 releaseCall: ${this.releaseCall} \
-                 releaseAged: ${this.releaseAged} \
-                 releaseReplaced: ${this.releaseReplaced} \
-                 releasePushActive: ${this.releasePushActive} \
-                 releaseCloseDead: ${this.releaseCloseDead} \
-      `);
+      logger.info(`makeConnection: pool: {this.poolId} ${JSON.stringify(this.counters)} free.length: ${this.free_connections.length} all_connections.length ${Object.keys(this.all_connections).length}`);
     const driver = new Driver();
     let connection = await driver.connect(this.config.connectionConfig);
     const results = await connection.execute(
@@ -229,7 +244,7 @@ class Pool {
     //    connection._defaultClose = connection.close;
     connection._defaultOrigClose = connection.close;
     connection._defaultClose = async () => {
-      this.closeCall += 1;
+      this.counters.defaultCall += 1;
       try {
         await connection._defaultOrigClose();
       } catch (err) {
@@ -238,7 +253,7 @@ class Pool {
           throw err;
         }
       }
-      this.closeNext += 1;
+      this.counters.defaultExit += 1;
     };
     connection.close = async () => {
       await thisPool.releaseConnection(connection);
@@ -256,14 +271,16 @@ class Pool {
     };
 
     this.all_connections[_id].ageOutID = setTimeout(
-      () => this._closeConnection(_id),
+      () => {this.counters.setTimeout+=1;this._closeConnection(_id)},
       this.config.maxAge,
       _id
     );
+    this.counters.makeExit += 1;
     return connection;
   }
 
   async _createConnection() {
+    this.counters.createCall += 1;
     let error;
     let connectionMade;
     let tries = 0;
@@ -272,39 +289,28 @@ class Pool {
       try {
         connectionMade = await this._makeConnection();
       } catch (err) {
+        logger.error(err, "createConnection");
         tries++;
         error = err;
       }
     }
     if (tries >= maxTries) {
-      logger.error(error, "createConnection");
+      logger.error(error, "createRetry");
       throw error;
     }
+    this.counters.createExit += 1;
     return connectionMade;
   }
 
   async requestConnection() {
-    this.callRequest = +1;
+    this.counters.requestCall = +1;
     if (
       Object.keys(this.all_connections).length > this.config.maxLimit ||
-      this.closeCall != this.closeNext
+      this.counters.closeCall != this.counters.closeExit
     ) {
       logger.level = "info";
     }
-    logger.info(`\ 
-                 closeCall: ${this.closeCall} \
-                 closeNext: ${this.closeNext} \
-                 requestConnection: pool: ${this.poolId} \
-                 free.length: ${this.free_connections.length} \
-                 all_connections.length: ${
-                   Object.keys(this.all_connections).length
-                 } \
-                 releaseCall: ${this.releaseCall} \
-                 releaseAged: ${this.releaseAged} \
-                 releaseReplaced: ${this.releaseReplaced} \
-                 releasePushActive: ${this.releasePushActive} \
-                 releaseCloseDead: ${this.releaseCloseDead} \
-      `);
+    logger.info(`requestConnection: pool: {this.poolId} ${JSON.stringify(this.counters)} free.length: ${this.free_connections.length} all_connections.length ${Object.keys(this.all_connections).length}`);
     if (this.state === Pool.STATE_INITIALIZING) {
       let err = new Error(
         "must initialize the pool before requesting a connection"
@@ -317,30 +323,30 @@ class Pool {
       logger.error(err);
       throw err;
     }
+
+    let connectionToUse = null;
     // if there is a free connection, use it
     if (this.free_connections.length > 0) {
       this.freeRequest = +1;
-      const connectionToUse = this.free_connections.shift();
+      connectionToUse = this.free_connections.shift();
       this.all_connections[connectionToUse._id].inUse = true;
-      return connectionToUse;
-      // if there are no free connection and we are not at maxLimit then create a connection
-    } else if (
-      Object.keys(this.all_connections).length < this.config.maxLimit
-    ) {
+    // if there are no free connection and we are not at maxLimit then create a connection
+    } else if ( Object.keys(this.all_connections).length < this.config.maxLimit) {
       this.createRequest = +1;
-      const connectionToUse = await this._createConnection();
+      connectionToUse = await this._createConnection();
       this.all_connections[connectionToUse._id].inUse = true;
-      return connectionToUse;
-      // there is no free connection, but maxLimit has been reached
+    // there is no free connection, but maxLimit has been reached
     } else {
       let err = new Error("connection hard limit reached");
       logger.error(err);
       throw err;
     }
+    this.counters.requestExit = +1;
+    return connectionToUse;
   }
 
   async releaseConnection(connection) {
-    this.releaseCall += 1;
+    this.counters.releaseCall += 1;
     if (this.state !== Pool.STATE_RUNNING) {
       let err = new Error(
         `cannot release connections to a pool that is not running, current state: ${this.state}`
@@ -362,7 +368,7 @@ class Pool {
     }
     // if aged out connection is returned to the pool, close it
     if (this.all_connections[connection._id].ageStatus === true) {
-      this.releaseAged += 1;
+      this.counters.releaseAged += 1;
       try {
         await clearTimeout(this.all_connections[connection._id].ageOutID);
         await connection._defaultClose();
@@ -383,21 +389,22 @@ class Pool {
         let newConn = await this._createConnection();
         this.free_connections.push(newConn);
       }
-
-      return;
-    }
-    // If the connection has not aged out, determine if the connection has any problem
-    // close any bad connection and avoid returning a bad connection to the pool
-    // all connections that are still useable can be returned to the pool
-    const connectionAlive = await this._checkConnection(connection); //returns boolean
-    if (connectionAlive) {
-      this.releasePushAlive += 1;
-      this.all_connections[connection._id].inUse = false;
-      this.free_connections.push(connection);
     } else {
-      this.releaseCloseDead += 1;
-      await this._closeConnection(connection._id);
+      // If the connection has not aged out, determine if the connection has any problem
+      // close any bad connection and avoid returning a bad connection to the pool
+      // all connections that are still useable can be returned to the pool
+      const connectionAlive = await this._checkConnection(connection); //returns boolean
+      if (connectionAlive) {
+        this.releasePushAlive += 1;
+        this.all_connections[connection._id].inUse = false;
+        this.free_connections.push(connection);
+      } else {
+        this.counters.releaseCloseDead += 1;
+        await this._closeConnection(connection._id);
+      }
     }
+    this.counters.releaseExit += 1;
+    return;
   }
 
   async closePool() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-nuodb",
-  "version": "3.5.6",
+  "version": "3.5.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-nuodb",
-      "version": "3.5.6",
+      "version": "3.5.7",
       "license": "Apache-2.0",
       "dependencies": {
         "bindings": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "NuoDB, Inc.",
   "description": "The official NuoDB driver for Node.js. Provides a high-level SQL API on top of the NuoDB Node.js Addon.",
   "license": "Apache-2.0",
-  "version": "3.5.6",
+  "version": "3.5.7",
   "main": "index.js",
   "keywords": [
     "nuodb",


### PR DESCRIPTION
These changes add a number extra counters to the pool.js code, primarily to advance debugging connection growth.  The counters were all put under an object called counters.  Some functions were changed to have a single exit at the bottom of the routine when code runs without error.