### PR TITLE
Fix the testing environment using docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ format:
 #:help: build       | Creates a `build` Docker image variant
 .PHONY: build
 build:
+	docker network create nuodb-net || true
 	docker build --target build --network nuodb-net -f dockers/slim/Dockerfile -t nuodb/node-nuodb:$(VERSION)-build .
 
 #:help: test        | Runs the `test` target, building and testing the driver.

--- a/test/config.json
+++ b/test/config.json
@@ -1,7 +1,7 @@
 {
   "DBConnect":
     {
-	"database" : "test@nuordc01:48004",
+	"database" : "test@ad1:48004",
 	"user" : "dba",
 	"password" : "dba",
 	"schema" : "USER"


### PR DESCRIPTION
- Make sure the nuodb-net is created when starting docker env
- Change the test config file to point the database to the correct testing host.