### PR TITLE
change package name from node-nuodb to just nuodb

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 Node.js NAN C++ NuoDB Driver
 
-The node-nuodb add-on for Node.js powers high performance NuoDB Database applications.
+The nuodb driver add-on for Node.js powers high performance NuoDB Database applications.
 
-Use node-nuodb to connect Node.js to a NuoDB Database.
+Use nuodb driver to connect Node.js to a NuoDB Database.
 
-node-nuodb supports basic features of the NuoDB Database and NuoDB C++ client.
+nuodb driver supports basic features of the NuoDB Database and NuoDB C++ client.
 
 ## Dependencies
 
@@ -35,7 +35,7 @@ If you have NuoDB installed locally, skip to step 4
    npm test
 
 7. Import the driver into your node.js project.
-   var Driver = require('/path/to/driver/repo/node-nuodb');
+   var Driver = require('/path/to/driver/repo/nuodb');
 
 ## Documentation
 
@@ -174,7 +174,7 @@ Any `try` `catch` block in which NuoDB resources are created must be followed by
 
 ## Help
 
-Issues and questions about node-nuodb can be posted on [GitHub][2].
+Issues and questions about nuodb driver can be posted on [GitHub][2].
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "index.js",
   "keywords": [
     "nuodb",
-    "dataabase",
+    "database",
     "SQL"
     "driver",
     "official"

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "node-nuodb",
-  "author": "NuoDB, Inc.",
+  "name": "nuodb",
+  "author": "Dassault Systèmes SE",
   "description": "The official NuoDB driver for Node.js. Provides a high-level SQL API on top of the NuoDB Node.js Addon.",
   "license": "Apache-2.0",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "main": "index.js",
   "keywords": [
     "nuodb",
@@ -24,7 +24,6 @@
   "gypfile": true,
   "dependencies": {
     "bindings": "^1.5.0",
-    "js-beautify": "^1.14.9",
     "nan": "^2.17.0",
     "nconf": "^0.12.0",
     "node-gyp": "^8.4.1",
@@ -36,6 +35,7 @@
   "devDependencies": {
     "async": "^3.2.3",
     "eslint": "^8.6.0",
+    "js-beautify": "^1.14.9",
     "mocha": "^9.2.2",
     "okay": "^1.0.0",
     "should": "^13.2.3"

--- a/package.json
+++ b/package.json
@@ -1,12 +1,14 @@
 {
   "name": "nuodb",
   "author": "Dassault Systèmes SE",
-  "description": "The official NuoDB driver for Node.js. Provides a high-level SQL API on top of the NuoDB Node.js Addon.",
-  "license": "Apache-2.0",
+  "description": "The official NuoDB database driver for Node.js. Provides a high-level SQL API on top of the NuoDB Node.js Addon.",
+  "license": "BSD-3-Clause",
   "version": "3.7.0",
   "main": "index.js",
   "keywords": [
     "nuodb",
+    "dataabase",
+    "SQL"
     "driver",
     "official"
   ],


### PR DESCRIPTION
Primarily this is just to change the package name from node-nuodb to just nuodb, which seems to follow the common convention used by other database vendors.  I moved a module out of the dependency list to the dev list since it was just a code formatting tool.  