### PR TITLE
Initial fix to stop unterminated strings from being used in TIMESTAMP…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,15 @@
 {
-  "name": "node-nuodb",
-  "version": "3.5.8",
+  "name": "nuodb",
+  "version": "3.7.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "node-nuodb",
-      "version": "3.5.8",
-      "license": "Apache-2.0",
+      "name": "nuodb",
+      "version": "3.7.1.1",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "bindings": "^1.5.0",
-        "js-beautify": "^1.14.9",
         "nan": "^2.17.0",
         "nconf": "^0.12.0",
         "node-gyp": "^8.4.1",
@@ -22,6 +21,7 @@
       "devDependencies": {
         "async": "^3.2.3",
         "eslint": "^8.6.0",
+        "js-beautify": "^1.14.9",
         "mocha": "^9.2.2",
         "okay": "^1.0.0",
         "should": "^13.2.3"
@@ -111,7 +111,8 @@
     "node_modules/@one-ini/wasm": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
-      "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw=="
+      "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
+      "dev": true
     },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
@@ -556,6 +557,7 @@
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
       "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
       "engines": {
         "node": ">=14"
       }
@@ -569,6 +571,7 @@
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
       "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "dev": true,
       "dependencies": {
         "ini": "^1.3.4",
         "proto-list": "~1.2.1"
@@ -708,6 +711,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.4.tgz",
       "integrity": "sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==",
+      "dev": true,
       "dependencies": {
         "@one-ini/wasm": "0.1.1",
         "commander": "^10.0.0",
@@ -725,6 +729,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -733,6 +738,7 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
       "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -1334,7 +1340,8 @@
     "node_modules/ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true
     },
     "node_modules/ip": {
       "version": "1.1.5",
@@ -1431,6 +1438,7 @@
       "version": "1.14.9",
       "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.9.tgz",
       "integrity": "sha512-coM7xq1syLcMyuVGyToxcj2AlzhkDjmfklL8r0JgJ7A76wyGMpJ1oA35mr4APdYNO/o/4YY8H54NQIJzhMbhBg==",
+      "dev": true,
       "dependencies": {
         "config-chain": "^1.1.13",
         "editorconfig": "^1.0.3",
@@ -1450,6 +1458,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -1458,6 +1467,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
       "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -1476,6 +1486,7 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
       "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -1487,6 +1498,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-6.0.0.tgz",
       "integrity": "sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==",
+      "dev": true,
       "dependencies": {
         "abbrev": "^1.0.0"
       },
@@ -2192,7 +2204,8 @@
     "node_modules/proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "dev": true
     },
     "node_modules/punycode": {
       "version": "2.1.1",
@@ -2973,7 +2986,8 @@
     "@one-ini/wasm": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
-      "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw=="
+      "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
+      "dev": true
     },
     "@tootallnate/once": {
       "version": "1.1.2",
@@ -3290,7 +3304,8 @@
     "commander": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -3301,6 +3316,7 @@
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
       "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "dev": true,
       "requires": {
         "ini": "^1.3.4",
         "proto-list": "~1.2.1"
@@ -3416,6 +3432,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.4.tgz",
       "integrity": "sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==",
+      "dev": true,
       "requires": {
         "@one-ini/wasm": "0.1.1",
         "commander": "^10.0.0",
@@ -3427,6 +3444,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
           "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
           "requires": {
             "balanced-match": "^1.0.0"
           }
@@ -3435,6 +3453,7 @@
           "version": "9.0.1",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
           "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
+          "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"
           }
@@ -3882,7 +3901,8 @@
     "ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true
     },
     "ip": {
       "version": "1.1.5",
@@ -3955,6 +3975,7 @@
       "version": "1.14.9",
       "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.9.tgz",
       "integrity": "sha512-coM7xq1syLcMyuVGyToxcj2AlzhkDjmfklL8r0JgJ7A76wyGMpJ1oA35mr4APdYNO/o/4YY8H54NQIJzhMbhBg==",
+      "dev": true,
       "requires": {
         "config-chain": "^1.1.13",
         "editorconfig": "^1.0.3",
@@ -3966,6 +3987,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
           "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
           "requires": {
             "balanced-match": "^1.0.0"
           }
@@ -3974,6 +3996,7 @@
           "version": "8.1.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
           "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+          "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -3986,6 +4009,7 @@
           "version": "5.1.6",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
           "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+          "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"
           }
@@ -3994,6 +4018,7 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-6.0.0.tgz",
           "integrity": "sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==",
+          "dev": true,
           "requires": {
             "abbrev": "^1.0.0"
           }
@@ -4532,7 +4557,8 @@
     "proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "dev": true
     },
     "punycode": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "Dassault Systèmes SE",
   "description": "The official NuoDB database driver for Node.js. Provides a high-level SQL API on top of the NuoDB Node.js Addon.",
   "license": "BSD-3-Clause",
-  "version": "3.7.1",
+  "version": "3.7.1.1",
   "main": "index.js",
   "keywords": [
     "nuodb",

--- a/src/NuoJsConnection.cpp
+++ b/src/NuoJsConnection.cpp
@@ -563,19 +563,26 @@ NuoDB::PreparedStatement* Connection::createStatement(std::string sql, Local<Arr
                     break;
                 }
                 case NuoDB::NUOSQL_DATE: {
+		    int bufsize = 80;
                     char buffer[80];
+		    // Initializing buffer to string termination so there is
+		    // no possible unterminated string placed in the buffer.
+		    memset(buffer,'\0',bufsize);
                     time_t seconds = (time_t)(toInt64(value) / 1000);
                     struct tm* timeinfo;
                     timeinfo = localtime(&seconds);
-                    strftime(buffer, 80, "%F %T", timeinfo);
+                    strftime(buffer, bufsize, "%F %T", timeinfo);
+		    int strsize = strlen(buffer);
                     // buffer = "YYYY-MM-DD HH:MM:SS" -- 19 characters long
                     int ms = toInt64(value) % 1000;
-                    buffer[19] = '.';
-                    buffer[20] = '0' + ms / 100;
+                    buffer[strsize] = '.';
+                    buffer[++strsize] = '0' + ms / 100;
                     ms %= 100;
-                    buffer[21] = '0' + ms / 10;
+                    buffer[++strsize] = '0' + ms / 10;
                     ms %= 10;
-                    buffer[22] = '0' + ms;
+                    buffer[++strsize] = '0' + ms;
+		    
+		    assert (strsize < bufsize);
 
                     statement->setString(sqlIdx, buffer);
                     break;

--- a/test/typeHelper.js
+++ b/test/typeHelper.js
@@ -47,7 +47,7 @@ helper.dropTable = function (connection, tableName, done) {
 helper.insertDataArray = function (connection, tableName, values, done) {
   // console.log(values);
   async.series(values.map((value) => (cb) => {
-    // console.log(value);
+    console.log(value);
     connection.execute(helper.sqlInsert(tableName), [value], function (err, results) {
       should.not.exist(err);
       should.not.exist(results);

--- a/test/typeTestCases.js
+++ b/test/typeTestCases.js
@@ -1,4 +1,5 @@
 var should = require('should');
+var now = Date();
 const testCases = [
   {
     type: 'BINARY',
@@ -234,6 +235,8 @@ const testCases = [
       new Date('2015-07-23 23:00:00.789123'),
       new Date('2015-07-24 00:00:00.456789'),
       new Date('2015-07-23 12:34:56.123456'),
+      new Date('2023-09-16T07:36:49.693Z'),
+      new Date(now),
     ],
     checkResults: (rows) => {
       (rows).should.containEql({F1: new Date(-100000000)});
@@ -247,6 +250,8 @@ const testCases = [
       (rows).should.containEql({F1: new Date('2015-07-23 23:00:00.789123')});
       (rows).should.containEql({F1: new Date('2015-07-24 00:00:00.456789')});
       (rows).should.containEql({F1: new Date('2015-07-23 12:34:56.123456')});
+      (rows).should.containEql({F1: new Date('2023-09-16T07:36:49.693Z')});
+      (rows).should.containEql({F1: new Date(now)});
     }
   },
   {


### PR DESCRIPTION
3DMessage has seen intermittent failures using Dates, especially on Docker.  We don't have a reproducible test case but code inspection found a defect where strings were not specifically terminated, thus leaving it to chance if a string might have been terminated.  C++ makes no guarantees regarding the state of allocated memory, and the code was placing characters after an initial string was loaded, losing a guaranteed '\0' at the end of the string.