### PR TITLE
Added a switch to enable/disable PINO logging from PINO_LOG_ENABLED

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -8,6 +8,7 @@ const fileTransport = pino.transport({
 });
 
 module.exports = pino({
+  enabled: process.env.PINO_LOG_ENABLED || false,
   level: process.env.PINO_LOG_LEVEL || 'silent',
   formatters: {
     level: (label) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nuodb",
-  "version": "3.7.2",
+  "version": "3.7.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nuodb",
-      "version": "3.7.2",
+      "version": "3.7.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "bindings": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "Dassault Systèmes SE",
   "description": "The official NuoDB database driver for Node.js. Provides a high-level SQL API on top of the NuoDB Node.js Addon.",
   "license": "BSD-3-Clause",
-  "version": "3.7.2",
+  "version": "3.7.3",
   "main": "index.js",
   "keywords": [
     "nuodb",


### PR DESCRIPTION
Added a switch to enable/disable PINO logging from PINO_LOG_ENABLED, default setting is false.  This will prevent the current build up of logging information for production unless explicitly turned on.