### PR TITLE
Update NuoDB test environment to use latest version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,11 +23,11 @@ jobs:
             cd /tmp/nuodb-client-package && tar xf nuodb-client-package.tar.gz
             mv "/tmp/nuodb-client-package/$(basename "$NUODB_CLIENT_PACKAGE_URL" | sed 's/\.tar\.gz//g')" /tmp/nuodb-client-package/nuodb-client.lin-x64
       - run:
-          name: Make sure we have a clean environment
-          command: make dn
-      - run:
           name: Start NuoDB test database and run tests
           command: make up && make smoke-tests
+      - run:
+          name: Make sure we clean the test environment
+          command: make dn
 
   nightly_tests:
     docker:
@@ -51,11 +51,11 @@ jobs:
             cd /tmp/nuodb-client-package && tar xf nuodb-client-package.tar.gz
             mv "/tmp/nuodb-client-package/$(basename "$NUODB_CLIENT_PACKAGE_URL" | sed 's/\.tar\.gz//g')" /tmp/nuodb-client-package/nuodb-client.lin-x64
       - run:
-          name: Make sure we have a clean environment
-          command: make dn
-      - run:
           name: Start NuoDB test database and run tests
           command: make up && make nightly-tests
+      - run:
+          name: Make sure we clean the test environment
+          command: make dn
 parameters:
   run-nightly-tests:
     type: boolean

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,11 +64,15 @@ parameters:
 workflows:
   run_smoke_tests:
     jobs:
-      - smoke_tests
+      - smoke_tests:
+          context:
+            - common-config
 
   run_nightly_tests:
     when:
       when: << pipeline.parameters.run-nightly-tests >>
     jobs:
-      - nightly_tests
+      - nightly_tests:
+          context:
+            - common-config
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
           command: make dn || true
       - run:
           name: Start NuoDB test database and run tests
-          command: NUODB_LIMITED_LICENSE_CONTENT="$NUODB_LIMITED_LICENSE_CONTENT" make up && sleep 10 && make status && make smoke-tests
+          command: make up && sleep 10 && make status && make smoke-tests
 
   nightly_tests:
     docker:
@@ -55,7 +55,7 @@ jobs:
           command: make dn || true
       - run:
           name: Start NuoDB test database and run tests
-          command: NUODB_LIMITED_LICENSE_CONTENT="$NUODB_LIMITED_LICENSE_CONTENT" make up && sleep 10 && make status && make nightly-tests
+          command: make up && sleep 10 && make status && make nightly-tests
 parameters:
   run-nightly-tests:
     type: boolean

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
           command: make dn || true
       - run:
           name: Start NuoDB test database and run tests
-          command: make up && sleep 10 && make status && make smoke-tests
+          command: NUODB_LIMITED_LICENSE_CONTENT="$NUODB_LIMITED_LICENSE_CONTENT" make up && sleep 10 && make status && make smoke-tests
 
   nightly_tests:
     docker:
@@ -55,7 +55,7 @@ jobs:
           command: make dn || true
       - run:
           name: Start NuoDB test database and run tests
-          command: make up && sleep 10 && make status && make nightly-tests
+          command: NUODB_LIMITED_LICENSE_CONTENT="$NUODB_LIMITED_LICENSE_CONTENT" make up && sleep 10 && make status && make nightly-tests
 parameters:
   run-nightly-tests:
     type: boolean

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,10 +24,10 @@ jobs:
             mv "/tmp/nuodb-client-package/$(basename "$NUODB_CLIENT_PACKAGE_URL" | sed 's/\.tar\.gz//g')" /tmp/nuodb-client-package/nuodb-client.lin-x64
       - run:
           name: Make sure we have a clean environment
-          command: make dn || true
+          command: make dn
       - run:
           name: Start NuoDB test database and run tests
-          command: make up && sleep 10 && make status && make smoke-tests
+          command: make up && make smoke-tests
 
   nightly_tests:
     docker:
@@ -52,10 +52,10 @@ jobs:
             mv "/tmp/nuodb-client-package/$(basename "$NUODB_CLIENT_PACKAGE_URL" | sed 's/\.tar\.gz//g')" /tmp/nuodb-client-package/nuodb-client.lin-x64
       - run:
           name: Make sure we have a clean environment
-          command: make dn || true
+          command: make dn
       - run:
           name: Start NuoDB test database and run tests
-          command: make up && sleep 10 && make status && make nightly-tests
+          command: make up && make nightly-tests
 parameters:
   run-nightly-tests:
     type: boolean

--- a/build-support/scripts/dn
+++ b/build-support/scripts/dn
@@ -1,8 +1,28 @@
 #!/usr/bin/env bash
 
-docker stop te1 te2 sm1 ad1
-docker network rm nuodb-net
-##rm -fr vol1 vol2
+COMMAND="docker exec ad1 nuocmd check database --db-name test --check-running"
+if ! $COMMAND 2>/dev/null; then
+    echo "Environment already cleaned."
+    exit 0
+fi
 
-#added to properly remove newly created volumes
-docker volume rm vol1 vol2 cores valgrind
+
+echo "Stopping NuoDB environment.... "
+for c in te1 te2 sm1 ad1; do
+    echo -n "- "
+    docker stop "$c"
+done
+echo "Done!"
+echo
+echo -n "Remove local network..."
+docker network rm nuodb-net
+echo "Done!"
+echo
+echo "Remove local volumes..."
+for vol in vol1 vol2 cores valgrind; do
+    echo -n "- "
+    docker volume rm "$vol" 2>/dev/null || echo "'$vol' volume already removed."
+done
+echo "Done!"
+echo
+echo "Environment cleaned."

--- a/build-support/scripts/dn
+++ b/build-support/scripts/dn
@@ -1,22 +1,24 @@
 #!/usr/bin/env bash
 
-COMMAND="docker exec ad1 nuocmd check database --db-name test --check-running"
-if ! $COMMAND 2>/dev/null; then
-    echo "Environment already cleaned."
-    exit 0
-fi
-
-
 echo "Stopping NuoDB environment.... "
-for c in te1 te2 sm1 ad1; do
-    echo -n "- "
-    docker stop "$c"
+containers=("te1" "te2" "sm1" "ad1")
+for container in "${containers[@]}"; do
+    if docker ps -a | grep -q "$container"; then
+        echo -n "- "
+        docker stop "$container"
+    else
+        echo "'$container' alredy stopped."
+    fi
 done
 echo "Done!"
 echo
-echo -n "Remove local network..."
-docker network rm nuodb-net
-echo "Done!"
+echo -n "Remove local network... "
+if docker network rm nuodb-net 2>/dev/null; then
+    echo "Done!"
+else
+    echo "Local network already removed."
+fi
+
 echo
 echo "Remove local volumes..."
 for vol in vol1 vol2 cores valgrind; do

--- a/build-support/scripts/status
+++ b/build-support/scripts/status
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-: ${IMG_NAME:="nuodb/nuodb:5.1"}
+: ${IMG_NAME:="nuodb/nuodb:latest"}
 
 docker run -it --net nuodb-net ${IMG_NAME} \
     nuocmd --api-server ad1:8888 show domain

--- a/build-support/scripts/term
+++ b/build-support/scripts/term
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-: ${IMG_NAME:="nuodb/nuodb:5.1"}
+: ${IMG_NAME:="nuodb/nuodb:latest"}
 
 docker run -it --name term --rm \
     --net nuodb-net ${IMG_NAME} bash

--- a/build-support/scripts/up
+++ b/build-support/scripts/up
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-: ${IMG_NAME:="nuodb/nuodb:5.1"}
+: ${IMG_NAME:="nuodb/nuodb:latest"}
 
 docker network create nuodb-net
 
@@ -12,11 +12,25 @@ docker run -d --name ad1 --rm \
     -p 48005:48005 \
     -e "NUODB_DOMAIN_ENTRYPOINT=ad1" \
     ${IMG_NAME} nuoadmin
+
+COMMAND="docker exec -i ad1 nuocmd show domain"
+echo -n "Wating for AP to start..."
+while ! $COMMAND 2>/dev/null | grep -q "Connected"; do
+    echo -n "."
+    sleep 2
+done
+echo -e "\nAP started!"
+echo
+
+# Apply limited license
+echo -n "Applying license.. "
+docker exec -it -e "NUODB_LIMITED_LICENSE_CONTENT=$NUODB_LIMITED_LICENSE_CONTENT" ad1 /bin/bash -c 'echo "$NUODB_LIMITED_LICENSE_CONTENT" > ~/nuodb.lic && nuocmd set license --license-file ~/nuodb.lic && rm ~/nuodb.lic'
+echo "Done!"
+
 #changed to properly create and mount volumes
+echo "Starting SM1... "
 docker volume create vol1
-
 docker volume create vol2
-
 
 docker run -d --name sm1 --hostname sm1 --rm \
     --volume vol1:/var/opt/nuodb/backup \
@@ -27,7 +41,9 @@ docker run -d --name sm1 --hostname sm1 --rm \
     --dba-user dba --dba-password dba \
     --labels "zone east node localhost" \
     --archive-dir /var/opt/nuodb/archive
-
+echo "Done!"
+echo
+echo "Starting TEs... "
 docker run -d --name te1 --hostname te1 --rm \
     --net nuodb-net ${IMG_NAME} nuodocker \
     --api-server ad1:8888 start te \
@@ -37,3 +53,14 @@ docker run -d --name te2 --hostname te2 --rm \
     --net nuodb-net ${IMG_NAME} nuodocker \
     --api-server ad1:8888 start te \
     --db-name test --server-id ad1
+echo "Done!"
+
+echo -n "Wating for database to start..."
+while ! $COMMAND | grep -q "state = RUNNING"; do
+    echo "."
+    sleep 2
+done
+sleep 2
+echo "Done!"
+$COMMAND
+

--- a/build-support/scripts/up
+++ b/build-support/scripts/up
@@ -2,8 +2,18 @@
 
 : ${IMG_NAME:="nuodb/nuodb:latest"}
 
-docker network create nuodb-net
+COMMAND="docker exec ad1 nuocmd check database --db-name test --check-running"
+if $COMMAND 2>/dev/null; then
+    echo "Environment already created."
+    docker exec ad1 nuocmd show domain
+    exit 0
+fi
 
+echo "Creating local network.... "
+docker network create nuodb-net
+echo "Done!"
+echo
+echo "Creating AP... "
 docker run -d --name ad1 --rm \
     --hostname ad1 \
     --net nuodb-net \
@@ -11,31 +21,29 @@ docker run -d --name ad1 --rm \
     -p 48004:48004 \
     -p 48005:48005 \
     -e "NUODB_DOMAIN_ENTRYPOINT=ad1" \
-    ${IMG_NAME} nuoadmin
-
-COMMAND="docker exec -i ad1 nuocmd show domain"
-echo -n "Wating for AP to start..."
-while ! $COMMAND 2>/dev/null | grep -q "Connected"; do
-    echo -n "."
-    sleep 2
-done
-echo -e "\nAP started!"
+    "${IMG_NAME}" nuoadmin
+echo "Done!"
 echo
+echo -n "Wating for AP to start... "
+docker exec ad1 nuocmd check servers --check-leader --check-connected --timeout 30
+echo "Connected!"
 
 # Apply limited license
 echo -n "Applying license.. "
-docker exec -it -e "NUODB_LIMITED_LICENSE_CONTENT=$NUODB_LIMITED_LICENSE_CONTENT" ad1 /bin/bash -c 'echo "$NUODB_LIMITED_LICENSE_CONTENT" | base64 -d > ~/nuodb.lic && nuocmd set license --license-file ~/nuodb.lic && rm ~/nuodb.lic'
+docker exec -e "NUODB_LIMITED_LICENSE_CONTENT=$NUODB_LIMITED_LICENSE_CONTENT" ad1 /bin/bash -c 'echo "$NUODB_LIMITED_LICENSE_CONTENT" | base64 -d > ~/nuodb.lic && nuocmd set license --license-file ~/nuodb.lic && rm ~/nuodb.lic'
 echo "Done!"
-
+echo
 #changed to properly create and mount volumes
+echo "Creating volumes for SM... "
+echo -e "- "; docker volume create vol1
+echo -e "- "; docker volume create vol2
+echo "Done!"
+echo
 echo "Starting SM1... "
-docker volume create vol1
-docker volume create vol2
-
 docker run -d --name sm1 --hostname sm1 --rm \
     --volume vol1:/var/opt/nuodb/backup \
     --volume vol2:/var/opt/nuodb/archive \
-    --net nuodb-net ${IMG_NAME} nuodocker \
+    --net nuodb-net "${IMG_NAME}" nuodocker \
     --api-server ad1:8888 start sm \
     --db-name test --server-id ad1 \
     --dba-user dba --dba-password dba \
@@ -45,13 +53,23 @@ echo "Done!"
 echo
 echo "Starting TEs... "
 docker run -d --name te1 --hostname te1 --rm \
-    --net nuodb-net ${IMG_NAME} nuodocker \
+    --net nuodb-net "${IMG_NAME}" nuodocker \
     --api-server ad1:8888 start te \
     --db-name test --server-id ad1
 
 docker run -d --name te2 --hostname te2 --rm \
-    --net nuodb-net ${IMG_NAME} nuodocker \
+    --net nuodb-net "${IMG_NAME}" nuodocker \
     --api-server ad1:8888 start te \
     --db-name test --server-id ad1
 echo "Done!"
+echo
+echo -n "Waiting for database to start..."
+COMMAND="docker exec ad1 nuocmd check database --db-name test --check-running"
+while ! $COMMAND 2>/dev/null; do
+    echo -n "."
+    sleep 2
+done
+echo " Running!"
+echo
+docker exec ad1 nuocmd show domain
 

--- a/build-support/scripts/up
+++ b/build-support/scripts/up
@@ -24,7 +24,7 @@ echo
 
 # Apply limited license
 echo -n "Applying license.. "
-docker exec -it -e "NUODB_LIMITED_LICENSE_CONTENT=$NUODB_LIMITED_LICENSE_CONTENT" ad1 /bin/bash -c 'echo "$NUODB_LIMITED_LICENSE_CONTENT" > ~/nuodb.lic && nuocmd set license --license-file ~/nuodb.lic && rm ~/nuodb.lic'
+docker exec -it -e "NUODB_LIMITED_LICENSE_CONTENT=$NUODB_LIMITED_LICENSE_CONTENT" ad1 /bin/bash -c 'echo "$NUODB_LIMITED_LICENSE_CONTENT" | base64 -d > ~/nuodb.lic && nuocmd set license --license-file ~/nuodb.lic && rm ~/nuodb.lic'
 echo "Done!"
 
 #changed to properly create and mount volumes

--- a/build-support/scripts/up
+++ b/build-support/scripts/up
@@ -55,12 +55,3 @@ docker run -d --name te2 --hostname te2 --rm \
     --db-name test --server-id ad1
 echo "Done!"
 
-echo -n "Wating for database to start..."
-while ! $COMMAND | grep -q "state = RUNNING"; do
-    echo "."
-    sleep 2
-done
-sleep 2
-echo "Done!"
-$COMMAND
-

--- a/dockers/centos/Dockerfile
+++ b/dockers/centos/Dockerfile
@@ -6,7 +6,7 @@
 # -------------------------------------
 # nuodb image
 
-FROM nuodb/nuodb:5.1 AS nuodb
+FROM nuodb/nuodb:latest AS nuodb
 
 # -------------------------------------
 # build image

--- a/dockers/slim/Dockerfile
+++ b/dockers/slim/Dockerfile
@@ -6,7 +6,7 @@
 # -------------------------------------
 # nuodb image
 
-FROM nuodb/nuodb:5.1 AS nuodb
+FROM nuodb/nuodb:latest AS nuodb
 
 # -------------------------------------
 # build image


### PR DESCRIPTION
New versions of NuoDB >6.0 require a license.
This change applies a license provided by CircleCI common-config context so that tests can run against new versions of NuoDB.