### PR TITLE
Add code coverage reporting support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,12 +79,12 @@ jobs:
             mv "/tmp/nuodb-client-package/$(basename "$NUODB_CLIENT_PACKAGE_URL" | sed 's/\.tar\.gz//g')" /tmp/nuodb-client-package/nuodb-client.lin-x64
       - run:
           name: Start NuoDB test database and run tests
-          command: make up && make coverage-smoke && ls -l && ls -l /
+          command: make up && make coverage-smoke && ls -l && ls -l /home/circleci/project && ls -l /home/circleci/project/coverage
       - run:
           name: Make sure we clean the test environment
           command: make dn
       - store_artifacts:
-          path: /coverage
+          path: /home/circleci/project/coverage
           destination: coverage-smoke-report
 parameters:
   run-nightly-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,9 +83,7 @@ jobs:
             make up && \
             make coverage-smoke && \
             ls -las && \
-            ls -las "$CIRCLE_WORKING_DIRECTORY/coverage" && \
-            cp -r "$CIRCLE_WORKING_DIRECTORY/coverage" /tmp/
-
+            ls -las /tmp/coverage
       - run:
           name: Make sure we clean the test environment
           command: make dn

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,13 +82,15 @@ jobs:
           command: |
             make up && \
             make coverage-smoke && \
-            cp -r ./coverage /tmp/
+            ls -las && \
+            ls -las "$CIRCLE_WORKING_DIRECTORY/coverage" && \
+            cp -r "$CIRCLE_WORKING_DIRECTORY/coverage" /tmp/
 
       - run:
           name: Make sure we clean the test environment
           command: make dn
       - store_artifacts:
-          path: /coverage
+          path: /tmp/coverage
           destination: coverage-smoke-report
 parameters:
   run-nightly-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,12 +79,12 @@ jobs:
             mv "/tmp/nuodb-client-package/$(basename "$NUODB_CLIENT_PACKAGE_URL" | sed 's/\.tar\.gz//g')" /tmp/nuodb-client-package/nuodb-client.lin-x64
       - run:
           name: Start NuoDB test database and run tests
-          command: make up && make coverage-smoke && ls -l
+          command: make up && make coverage-smoke && ls -l && ls -l /
       - run:
           name: Make sure we clean the test environment
           command: make dn
       - store_artifacts:
-          path: /tmp/coverage
+          path: /coverage
           destination: coverage-smoke-report
 parameters:
   run-nightly-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,12 +79,12 @@ jobs:
             mv "/tmp/nuodb-client-package/$(basename "$NUODB_CLIENT_PACKAGE_URL" | sed 's/\.tar\.gz//g')" /tmp/nuodb-client-package/nuodb-client.lin-x64
       - run:
           name: Start NuoDB test database and run tests
-          command: make up && make coverage-smoke
+          command: make up && make coverage-smoke && tree ./coverage && cp -r ./coverage /tmp/coverage
       - run:
           name: Make sure we clean the test environment
           command: make dn
       - store_artifacts:
-          path: ./coverage
+          path: /tmp/coverage
           destination: coverage-smoke-report
 parameters:
   run-nightly-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,12 +79,16 @@ jobs:
             mv "/tmp/nuodb-client-package/$(basename "$NUODB_CLIENT_PACKAGE_URL" | sed 's/\.tar\.gz//g')" /tmp/nuodb-client-package/nuodb-client.lin-x64
       - run:
           name: Start NuoDB test database and run tests
-          command: make up && make coverage-smoke
+          command: |
+            make up && \
+            make coverage-smoke && \
+            cp -r ./coverage /tmp/
+
       - run:
           name: Make sure we clean the test environment
           command: make dn
       - store_artifacts:
-          path: $CIRCLE_WORKING_DIRECTORY/coverage
+          path: /coverage
           destination: coverage-smoke-report
 parameters:
   run-nightly-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
             mv "/tmp/nuodb-client-package/$(basename "$NUODB_CLIENT_PACKAGE_URL" | sed 's/\.tar\.gz//g')" /tmp/nuodb-client-package/nuodb-client.lin-x64
       - run:
           name: Start NuoDB test database and run tests
-          command: make up && make coverage-smoke && tree ./coverage && cp -r ./coverage /tmp/coverage
+          command: make up && make coverage-smoke && ls -l ./coverage && cp -r ./coverage /tmp/coverage
       - run:
           name: Make sure we clean the test environment
           command: make dn

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,12 +79,12 @@ jobs:
             mv "/tmp/nuodb-client-package/$(basename "$NUODB_CLIENT_PACKAGE_URL" | sed 's/\.tar\.gz//g')" /tmp/nuodb-client-package/nuodb-client.lin-x64
       - run:
           name: Start NuoDB test database and run tests
-          command: make up && make coverage-smoke && ls -l && ls -l /home/circleci/project && ls -l /home/circleci/project/coverage
+          command: make up && make coverage-smoke
       - run:
           name: Make sure we clean the test environment
           command: make dn
       - store_artifacts:
-          path: /home/circleci/project/coverage
+          path: $CIRCLE_WORKING_DIRECTORY/coverage
           destination: coverage-smoke-report
 parameters:
   run-nightly-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
             mv "/tmp/nuodb-client-package/$(basename "$NUODB_CLIENT_PACKAGE_URL" | sed 's/\.tar\.gz//g')" /tmp/nuodb-client-package/nuodb-client.lin-x64
       - run:
           name: Start NuoDB test database and run tests
-          command: make up && make coverage-smoke && ls -l ./coverage && cp -r ./coverage /tmp/coverage
+          command: make up && make coverage-smoke && ls -l
       - run:
           name: Make sure we clean the test environment
           command: make dn

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
           command: |
             make up && \
             make coverage-smoke && \
-            ls -las && \
+            scp -r remote-docker:~/project/coverage /tmp/ && \
             ls -las /tmp/coverage
       - run:
           name: Make sure we clean the test environment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,36 @@ jobs:
       - run:
           name: Make sure we clean the test environment
           command: make dn
+  coverage_smoke:
+    docker:
+      - image: cimg/node:18.18
+    resource_class: 'medium'
+    environment:
+      NUODB_CLIENT_PACKAGE: '/tmp/nuodb-client-package/nuodb-client.lin-x64'
+      DOCKER_BUILDKIT: 'false'
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Get latest NuoDB Client package
+          command: |
+            mkdir /tmp/nuodb-client-package
+            export NUODB_CLIENT_PACKAGE_URL="$(curl -s https://api.github.com/repos/nuodb/nuodb-client/releases/latest \
+            | grep "browser_download_url.*tar.gz" \
+            | cut -d : -f 2,3 \
+            | tr -d " " | tr -d \")"
+            wget -O /tmp/nuodb-client-package/nuodb-client-package.tar.gz -q "$NUODB_CLIENT_PACKAGE_URL"
+            cd /tmp/nuodb-client-package && tar xf nuodb-client-package.tar.gz
+            mv "/tmp/nuodb-client-package/$(basename "$NUODB_CLIENT_PACKAGE_URL" | sed 's/\.tar\.gz//g')" /tmp/nuodb-client-package/nuodb-client.lin-x64
+      - run:
+          name: Start NuoDB test database and run tests
+          command: make up && make coverage-smoke
+      - run:
+          name: Make sure we clean the test environment
+          command: make dn
+      - store_artifacts:
+          path: ./coverage
+          destination: coverage-smoke-report
 parameters:
   run-nightly-tests:
     type: boolean
@@ -65,6 +95,9 @@ workflows:
   run_smoke_tests:
     jobs:
       - smoke_tests:
+          context:
+            - common-config
+      - coverage_smoke:
           context:
             - common-config
 

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,30 @@ smoke-tests: build
 	docker volume create valgrind
 	docker run ${TTY} --cap-add=SYS_PTRACE --memory 1g --volume cores:/cores --volume valgrind:/valgrind --name test --rm --network nuodb-net nuodb/node-nuodb:$(VERSION)-build npm run test-smoke
 
+#:help: coverage-smoke        | Runs the `test` target and generates code coverage report.
+#changed to properly create and mount volumes
+.PHONY: coverage-smoke
+coverage-smoke: build
+	docker volume create cores
+	docker volume create valgrind
+	docker run ${TTY} --cap-add=SYS_PTRACE --memory 1g --volume cores:/cores --volume valgrind:/valgrind --volume $(shell pwd)/coverage:/coverage --name test --rm --network nuodb-net nuodb/node-nuodb:$(VERSION)-build npm run coverage-smoke
+
+#:help: this-coverage        | Runs the `test` target and generates code coverage report.
+#changed to properly create and mount volumes
+.PHONY: this-coverage
+this-coverage: build
+	docker volume create cores
+	docker volume create valgrind
+	docker run ${TTY} --cap-add=SYS_PTRACE --memory 1g --volume cores:/cores --volume valgrind:/valgrind --volume $(shell pwd)/coverage:/coverage --name test --rm --network nuodb-net nuodb/node-nuodb:$(VERSION)-build npm run this-coverage
+
+#:help: x-this-coverage        | Runs the `test` target and generates code coverage report.
+#changed to properly create and mount volumes
+.PHONY: x-this-coverage
+x-this-coverage: build
+	docker volume create cores
+	docker volume create valgrind
+	docker run ${TTY} --cap-add=SYS_PTRACE --memory 1g --volume cores:/cores --volume valgrind:/valgrind --volume $(shell pwd)/coverage:/coverage --name test --rm --network nuodb-net nuodb/node-nuodb:$(VERSION)-build npm run x-this-coverage
+
 #:help: nightly-tests        | Runs the `test-nightly` target which takes longer to run.
 .PHONY: nightly-tests
 nightly-tests: build

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ smoke-tests: build
 coverage-smoke: build
 	docker volume create cores
 	docker volume create valgrind
-	docker run ${TTY} --cap-add=SYS_PTRACE --memory 1g --volume cores:/cores --volume valgrind:/valgrind --volume /tmp/coverage:/coverage --name test --rm --network nuodb-net nuodb/node-nuodb:$(VERSION)-build npm run coverage-smoke
+	docker run ${TTY} --cap-add=SYS_PTRACE --memory 1g --volume cores:/cores --volume valgrind:/valgrind --volume $(shell pwd)/coverage:/coverage --name test --rm --network nuodb-net nuodb/node-nuodb:$(VERSION)-build npm run coverage-smoke
 
 #:help: this-coverage        | Runs the `test` target and generates code coverage report.
 #changed to properly create and mount volumes
@@ -56,7 +56,7 @@ coverage-smoke: build
 this-coverage: build
 	docker volume create cores
 	docker volume create valgrind
-	docker run ${TTY} --cap-add=SYS_PTRACE --memory 1g --volume cores:/cores --volume valgrind:/valgrind --volume /tmp/coverage:/coverage --name test --rm --network nuodb-net nuodb/node-nuodb:$(VERSION)-build npm run this-coverage
+	docker run ${TTY} --cap-add=SYS_PTRACE --memory 1g --volume cores:/cores --volume valgrind:/valgrind --volume $(shell pwd)/coverage:/coverage --name test --rm --network nuodb-net nuodb/node-nuodb:$(VERSION)-build npm run this-coverage
 
 #:help: x-this-coverage        | Runs the `test` target and generates code coverage report.
 #changed to properly create and mount volumes
@@ -64,7 +64,7 @@ this-coverage: build
 x-this-coverage: build
 	docker volume create cores
 	docker volume create valgrind
-	docker run ${TTY} --cap-add=SYS_PTRACE --memory 1g --volume cores:/cores --volume valgrind:/valgrind --volume /tmp/coverage:/coverage --name test --rm --network nuodb-net nuodb/node-nuodb:$(VERSION)-build npm run x-this-coverage
+	docker run ${TTY} --cap-add=SYS_PTRACE --memory 1g --volume cores:/cores --volume valgrind:/valgrind --volume $(shell pwd)/coverage:/coverage --name test --rm --network nuodb-net nuodb/node-nuodb:$(VERSION)-build npm run x-this-coverage
 
 #:help: nightly-tests        | Runs the `test-nightly` target which takes longer to run.
 .PHONY: nightly-tests

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ smoke-tests: build
 coverage-smoke: build
 	docker volume create cores
 	docker volume create valgrind
-	docker run ${TTY} --cap-add=SYS_PTRACE --memory 1g --volume cores:/cores --volume valgrind:/valgrind --volume $(shell pwd)/coverage:/coverage --name test --rm --network nuodb-net nuodb/node-nuodb:$(VERSION)-build npm run coverage-smoke
+	docker run ${TTY} --cap-add=SYS_PTRACE --memory 1g --volume cores:/cores --volume valgrind:/valgrind --volume /tmp/coverage:/coverage --name test --rm --network nuodb-net nuodb/node-nuodb:$(VERSION)-build npm run coverage-smoke
 
 #:help: this-coverage        | Runs the `test` target and generates code coverage report.
 #changed to properly create and mount volumes
@@ -56,7 +56,7 @@ coverage-smoke: build
 this-coverage: build
 	docker volume create cores
 	docker volume create valgrind
-	docker run ${TTY} --cap-add=SYS_PTRACE --memory 1g --volume cores:/cores --volume valgrind:/valgrind --volume $(shell pwd)/coverage:/coverage --name test --rm --network nuodb-net nuodb/node-nuodb:$(VERSION)-build npm run this-coverage
+	docker run ${TTY} --cap-add=SYS_PTRACE --memory 1g --volume cores:/cores --volume valgrind:/valgrind --volume /tmp/coverage:/coverage --name test --rm --network nuodb-net nuodb/node-nuodb:$(VERSION)-build npm run this-coverage
 
 #:help: x-this-coverage        | Runs the `test` target and generates code coverage report.
 #changed to properly create and mount volumes
@@ -64,7 +64,7 @@ this-coverage: build
 x-this-coverage: build
 	docker volume create cores
 	docker volume create valgrind
-	docker run ${TTY} --cap-add=SYS_PTRACE --memory 1g --volume cores:/cores --volume valgrind:/valgrind --volume $(shell pwd)/coverage:/coverage --name test --rm --network nuodb-net nuodb/node-nuodb:$(VERSION)-build npm run x-this-coverage
+	docker run ${TTY} --cap-add=SYS_PTRACE --memory 1g --volume cores:/cores --volume valgrind:/valgrind --volume /tmp/coverage:/coverage --name test --rm --network nuodb-net nuodb/node-nuodb:$(VERSION)-build npm run x-this-coverage
 
 #:help: nightly-tests        | Runs the `test-nightly` target which takes longer to run.
 .PHONY: nightly-tests

--- a/Makefile
+++ b/Makefile
@@ -58,14 +58,6 @@ this-coverage: build
 	docker volume create valgrind
 	docker run ${TTY} --cap-add=SYS_PTRACE --memory 1g --volume cores:/cores --volume valgrind:/valgrind --volume $(shell pwd)/coverage:/coverage --name test --rm --network nuodb-net nuodb/node-nuodb:$(VERSION)-build npm run this-coverage
 
-#:help: x-this-coverage        | Runs the `test` target and generates code coverage report.
-#changed to properly create and mount volumes
-.PHONY: x-this-coverage
-x-this-coverage: build
-	docker volume create cores
-	docker volume create valgrind
-	docker run ${TTY} --cap-add=SYS_PTRACE --memory 1g --volume cores:/cores --volume valgrind:/valgrind --volume $(shell pwd)/coverage:/coverage --name test --rm --network nuodb-net nuodb/node-nuodb:$(VERSION)-build npm run x-this-coverage
-
 #:help: nightly-tests        | Runs the `test-nightly` target which takes longer to run.
 .PHONY: nightly-tests
 nightly-tests: build

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "x-this-coverage": "node-gyp rebuild -d && nyc npm run lint && nyc —-reporter=lcov —-reporter=text-lcov mocha --reporter spec --bail --check-leaks ",
     "test": "node-gyp rebuild -d && npm run lint && mocha --reporter spec --timeout 10000 --check-leaks test/",
     "test-smoke": "node-gyp rebuild -d && npm run lint && mocha --reporter spec --timeout 10000 --check-leaks --exclude='test/nightly/**' test/",
-    "coverage-smoke": "node-gyp rebuild -d && npm run lint && nyc --reporter=lcov --reporter=text-lcov mocha --reporter spec --timeout 10000 --check-leaks --exclude='test/nightly/**' test/",
+    "coverage-smoke": "node-gyp rebuild -d && npm run lint && nyc --report-dir /coverage --reporter=lcov --reporter=text-lcov mocha --reporter spec --timeout 10000 --check-leaks --exclude='test/nightly/**' test/",
     "test-nightly": "node-gyp rebuild -d && npm run lint && mocha --reporter spec --timeout 10000 --check-leaks test/nightly",
     "valgrind": "node-gyp rebuild -d && G_SLICE=always-malloc G_DEBUG=gc-friendly valgrind -v --tool=memcheck --leak-check=full --show-reachable=yes --num-callers=40 --log-file=/valgrind/valgrind.log $(which node) valgrind.js",
     "valgrind-test": "node-gyp rebuild -d && G_SLICE=always-malloc G_DEBUG=gc-friendly valgrind -v --tool=memcheck --leak-check=full --show-reachable=yes --num-callers=40 --log-file=/valgrind/valgrind.log mocha --reporter spec --bail --check-leaks test/"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "lint": "eslint index.js lib/*.js test/*.js",
     "this-test": "node-gyp rebuild -d && npm run lint && mocha --reporter spec --bail --check-leaks ",
     "this-coverage": "node-gyp rebuild -d && npm run lint && nyc --reporter=lcov --reporter=text-lcov mocha --reporter spec --bail --check-leaks ",
-    "x-this-coverage": "node-gyp rebuild -d && nyc npm run lint && nyc —-reporter=lcov —-reporter=text-lcov mocha --reporter spec --bail --check-leaks ",
     "test": "node-gyp rebuild -d && npm run lint && mocha --reporter spec --timeout 10000 --check-leaks test/",
     "test-smoke": "node-gyp rebuild -d && npm run lint && mocha --reporter spec --timeout 10000 --check-leaks --exclude='test/nightly/**' test/",
     "coverage-smoke": "node-gyp rebuild -d && npm run lint && nyc --report-dir /coverage --reporter=lcov --reporter=text-lcov mocha --reporter spec --timeout 10000 --check-leaks --exclude='test/nightly/**' test/",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "eslint": "^8.6.0",
     "js-beautify": "^1.14.9",
     "mocha": "^9.2.2",
+    "nyc": "^17.1.0",
     "okay": "^1.0.0",
     "should": "^13.2.3"
   },
@@ -45,8 +46,11 @@
     "build": "node-gyp rebuild -d",
     "lint": "eslint index.js lib/*.js test/*.js",
     "this-test": "node-gyp rebuild -d && npm run lint && mocha --reporter spec --bail --check-leaks ",
+    "this-coverage": "node-gyp rebuild -d && npm run lint && nyc --reporter=lcov --reporter=text-lcov mocha --reporter spec --bail --check-leaks ",
+    "x-this-coverage": "node-gyp rebuild -d && nyc npm run lint && nyc —-reporter=lcov —-reporter=text-lcov mocha --reporter spec --bail --check-leaks ",
     "test": "node-gyp rebuild -d && npm run lint && mocha --reporter spec --timeout 10000 --check-leaks test/",
     "test-smoke": "node-gyp rebuild -d && npm run lint && mocha --reporter spec --timeout 10000 --check-leaks --exclude='test/nightly/**' test/",
+    "coverage-smoke": "node-gyp rebuild -d && npm run lint && nyc --reporter=lcov --reporter=text-lcov mocha --reporter spec --timeout 10000 --check-leaks --exclude='test/nightly/**' test/",
     "test-nightly": "node-gyp rebuild -d && npm run lint && mocha --reporter spec --timeout 10000 --check-leaks test/nightly",
     "valgrind": "node-gyp rebuild -d && G_SLICE=always-malloc G_DEBUG=gc-friendly valgrind -v --tool=memcheck --leak-check=full --show-reachable=yes --num-callers=40 --log-file=/valgrind/valgrind.log $(which node) valgrind.js",
     "valgrind-test": "node-gyp rebuild -d && G_SLICE=always-malloc G_DEBUG=gc-friendly valgrind -v --tool=memcheck --leak-check=full --show-reachable=yes --num-callers=40 --log-file=/valgrind/valgrind.log mocha --reporter spec --bail --check-leaks test/"


### PR DESCRIPTION
Add new build target "coverage-smoke" which builds, tests and generates code coverage report.
This code coverage report will be available on CircleCI as artifacts.