### PR TITLE
Commit to run tests with Node 22 and necessary test changes to remove errors with NJS-22

### DIFF
--- a/dockers/slim/Dockerfile
+++ b/dockers/slim/Dockerfile
@@ -11,7 +11,7 @@ FROM nuodb/nuodb:latest AS nuodb
 # -------------------------------------
 # build image
 
-FROM node:18-slim AS build
+FROM node:22-slim AS build
 
 RUN apt-get -y update && apt-get install -y git gcc g++ make python3 eslint locales
 
@@ -37,7 +37,7 @@ RUN npm run build
 # -------------------------------------
 # release image
 
-FROM node:20-slim AS release
+FROM node:22-slim AS release
 
 COPY --from=build /opt/nuodb/lib64 /opt/nuodb/lib64
 COPY --from=build /src /src

--- a/test/7.typeTests.js
+++ b/test/7.typeTests.js
@@ -33,7 +33,7 @@ describe('7. testing types', async () => {
     await connection.close();
   });
 
-  // This particular test started to fail with Node 22 as shown in JIRA
+  // This particular test started to fail with Node 22 as shown in JIRA NJS-42
   // The use of promises was removed in favor of callbacks since it seem
   // to be more in-line with the basic of desired behavior which was to run
   // each subtest after the previous, all serialized.  I did see promises worked

--- a/test/7.typeTests.js
+++ b/test/7.typeTests.js
@@ -33,8 +33,13 @@ describe('7. testing types', async () => {
     await connection.close();
   });
 
-
-  await async.series(testCases.map((curr, index) => new Promise((res) => {
+  // This particular test started to fail with Node 22 as shown in JIRA
+  // The use of promises was removed in favor of callbacks since it seem
+  // to be more in-line with the basic of desired behavior which was to run
+  // each subtest after the previous, all serialized.  I did see promises worked
+  // using the following syntax, but it seemed more confuscated to me
+  // await async.series(testCases.map((curr, index) => async.asyncify(async () => { new Promise((res) => {
+  await async.series(testCases.map((curr, index) => { return function(callback) {
     const {data,type} = curr;
     // use specified table name for test if exists, otherwise determine programatically by type
     const tableName = curr.tableName ?? `table_${type}`;
@@ -56,7 +61,8 @@ describe('7. testing types', async () => {
       });
 
       after((done) => {
-        helper.dropTable(connection, tableName, () => {done();res();});
+        helper.dropTable(connection, tableName, () => {done();});
+        //helper.dropTable(connection, tableName, () => {done();res();});
       });
 
       it(`7.${index} result set stores ${type} correctly`, async () => {
@@ -70,5 +76,16 @@ describe('7. testing types', async () => {
         await results.close();
       });
     });
-  })));
+    callback(null,'OK');}}),
+  // Normally one would use function(err, results)
+  // but there is nothing to do with results when everything runs cleanly
+  function(err) {
+    if (err) {
+      console.error('Error:', err);
+    } else {
+      // If no error there is no reason to pring results
+      //console.log('Results:', results);
+    }
+  }
+  );
 });


### PR DESCRIPTION
These changes were needed to run tests with Node 22.  For some reason the original system produced errors when trying to use async.series from the async module available on NPM.  I also successfully tested these changes with Node 18 and Node 20 to double check the syntax works for this versions as well.  